### PR TITLE
ci: tolerant releases, SHA256SUMS+manifest.json, parallel ruby matrix, runner refresh

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -24,8 +24,8 @@
         { "host": "ubuntu-22.04-arm", "container": "ubuntu-20.04", "os": "linux-gnu", "arch": "arm64" },
         { "host": "ubuntu-22.04", "container": "alpine-3.17", "os": "linux-musl", "arch": "x86_64" },
         { "host": "ubuntu-22.04-arm", "container": "alpine-3.17", "os": "linux-musl", "arch": "arm64" },
-        { "host": "macos-15-intel", "container": null, "os": "macos", "arch": "x86_64" },
-        { "host": "macos-15", "container": null, "os": "macos", "arch": "arm64" },
+        { "host": "macos-15-intel", "container": null, "os": "macos", "arch": "x86_64", "xcode": "16.1" },
+        { "host": "macos-15", "container": null, "os": "macos", "arch": "arm64", "xcode": "16.1" },
         { "host": "windows-2022", "container": null, "os": "windows", "arch": "x86_64" }
     ]
 }

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -24,8 +24,8 @@
         { "host": "ubuntu-22.04-arm", "container": "ubuntu-20.04", "os": "linux-gnu", "arch": "arm64" },
         { "host": "ubuntu-22.04", "container": "alpine-3.17", "os": "linux-musl", "arch": "x86_64" },
         { "host": "ubuntu-22.04-arm", "container": "alpine-3.17", "os": "linux-musl", "arch": "arm64" },
-        { "host": "macos-13", "container": null, "os": "macos", "arch": "x86_64" },
-        { "host": "macos-14", "container": null, "os": "macos", "arch": "arm64" },
+        { "host": "macos-15-intel", "container": null, "os": "macos", "arch": "x86_64" },
+        { "host": "macos-15", "container": null, "os": "macos", "arch": "arm64" },
         { "host": "windows-2022", "container": null, "os": "windows", "arch": "x86_64" }
     ]
 }

--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -93,13 +93,14 @@ jobs:
           ./scripts/generate_matrix.rb
 
   build:
-    name: Build runtime packages for ${{ matrix.env.os }} / ${{ matrix.env.arch }}
+    name: Build runtime package for ${{ matrix.env.os }} / ${{ matrix.env.arch }} / Ruby ${{ matrix.ruby }}
     needs: prepare
     runs-on: ${{ matrix.env.host }}
     strategy:
       fail-fast: false
       matrix:
         env: ${{fromJson(needs.prepare.outputs.env-matrix)}}
+        ruby: ${{fromJson(needs.prepare.outputs.ruby-matrix)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -111,18 +112,26 @@ jobs:
         run: |
           mkdir -p runtime-packages
 
-      - name: Build runtimes using ci container
+      # Per-(platform, ruby) cache of the whole tebako prefix (.tebako), which
+      # holds both the ruby-independent deps and the ruby-specific press output.
+      # Host-native jobs only: container jobs build inside the CI container
+      # image whose deps are baked into the image itself, so there is no
+      # host-side path to cache (the container image is the cache).
+      - name: Cache tebako prefix
+        if: matrix.env.container == null
+        uses: actions/cache@v4
+        with:
+          path: .tebako
+          key: tebako-runtime-${{ matrix.env.os }}-${{ matrix.env.arch }}-${{ matrix.ruby }}-${{ needs.prepare.outputs.tebako-version }}-v${{ env.CACHE_VER }}
+
+      - name: Build runtime using ci container
         if: matrix.env.container != null
         run: |
           container="ghcr.io/tamatebako/tebako-${{ matrix.env.container }}:${{ needs.prepare.outputs.tebako-version }}"
-          # Parse the JSON array from ruby-matrix output
-          ruby_versions=$(echo '${{ needs.prepare.outputs.ruby-matrix }}' | jq -r '.[]')
-          for ruby_ver in $ruby_versions; do
-            echo "Building runtime for Ruby $ruby_ver on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
-            runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-$ruby_ver-${{ matrix.env.os }}-${{ matrix.env.arch }}"
-            docker run -v ${{github.workspace}}:/mnt/w -t $container \
-              tebako press -m runtime -o="/mnt/w/runtime-packages/$runtime" -R=${ruby_ver} ${{ matrix.env.os == 'linux-gnu' && '--patchelf' || '' }}
-          done
+          echo "Building runtime for Ruby ${{ matrix.ruby }} on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
+          runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-${{ matrix.ruby }}-${{ matrix.env.os }}-${{ matrix.env.arch }}"
+          docker run -v ${{github.workspace}}:/mnt/w -t $container \
+            tebako press -m runtime -o="/mnt/w/runtime-packages/$runtime" -R=${{ matrix.ruby }} ${{ matrix.env.os == 'linux-gnu' && '--patchelf' || '' }}
 
       - name: Setup MSys
         if: matrix.env.os == 'windows'
@@ -131,8 +140,6 @@ jobs:
           msystem: ucrt64
           path-type: minimal
           update: true
-          pacboy: >-
-            jq:p
 
       - name: Setup Tebako
         if: matrix.env.container == null
@@ -140,36 +147,31 @@ jobs:
         with:
           cache: build
           cache_ver: ${{ env.CACHE_VER }}
-          cache_path: .tebako
+          # Deps are ruby-independent, so the action's cache (keyed by tebako
+          # hash) covers only .tebako/deps and is shared across ruby versions;
+          # the ruby-specific press output is handled by the per-ruby cache above.
+          cache_path: .tebako/deps
 
-      - name: Build runtimes using gem
+      - name: Build runtime using gem
         if: matrix.env.container == null && matrix.env.os != 'windows'
         run: |
-          # Parse the JSON array from ruby-matrix output
-          ruby_versions=$(echo '${{ needs.prepare.outputs.ruby-matrix }}' | jq -r '.[]')
-          for ruby_ver in $ruby_versions; do
-            echo "Building runtime for Ruby $ruby_ver on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
-            runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-$ruby_ver-${{ matrix.env.os }}-${{ matrix.env.arch }}"
-            tebako press -m runtime -o "runtime-packages/$runtime" -R "$ruby_ver" -p .tebako
-          done
+          echo "Building runtime for Ruby ${{ matrix.ruby }} on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
+          runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-${{ matrix.ruby }}-${{ matrix.env.os }}-${{ matrix.env.arch }}"
+          tebako press -m runtime -o "runtime-packages/$runtime" -R "${{ matrix.ruby }}" -p .tebako
 
-      - name: Build runtimes using gem on Windows
+      - name: Build runtime using gem on Windows
         if: matrix.env.container == null && matrix.env.os == 'windows'
         shell: msys2 {0}
         run: |
           git config --global core.longpaths true
-          # Parse the JSON array from ruby-matrix output
-          ruby_versions=$(echo '${{ needs.prepare.outputs.ruby-matrix }}' | jq -r '.[]' | tr '\n' ' ' | tr '\r' ' ')
-          for ruby_ver in $ruby_versions; do
-            echo "Building runtime for Ruby $ruby_ver on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
-            runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-$ruby_ver-${{ matrix.env.os }}-${{ matrix.env.arch }}"
-            tebako press -m runtime -o "runtime-packages/$runtime" -R "$ruby_ver" -p .tebako
-          done
+          echo "Building runtime for Ruby ${{ matrix.ruby }} on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
+          runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-${{ matrix.ruby }}-${{ matrix.env.os }}-${{ matrix.env.arch }}"
+          tebako press -m runtime -o "runtime-packages/$runtime" -R "${{ matrix.ruby }}" -p .tebako
 
       - name: Upload runtime package
         uses: actions/upload-artifact@v4
         with:
-          name: runtime-packages-${{ matrix.env.os }}-${{ matrix.env.arch }}
+          name: runtime-packages-${{ matrix.env.os }}-${{ matrix.env.arch }}-${{ matrix.ruby }}
           path: runtime-packages
           retention-days: 1
 
@@ -177,7 +179,11 @@ jobs:
     name: Update release packages
     needs: [prepare, build]
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    # Never touch the production release from a pull request; otherwise run
+    # whenever the run was not cancelled, even if some build matrix legs
+    # failed (upload whatever artifacts exist; missing packages are reported
+    # loudly by scripts/upload_release.rb).
+    if: ${{ always() && !cancelled() && github.event_name != 'pull_request' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -202,6 +208,8 @@ jobs:
       - name: Update release using Ruby script
         env:
           TEBAKO_VERSION: ${{ needs.prepare.outputs.tebako-version }}
+          EXPECTED_ENV_MATRIX: ${{ needs.prepare.outputs.env-matrix }}
+          EXPECTED_RUBY_MATRIX: ${{ needs.prepare.outputs.ruby-matrix }}
           FORCE_REBUILD: ${{ github.event.inputs.force_rebuild == 'true' }}
         run: |
           ./scripts/upload_release.rb

--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -147,6 +147,10 @@ jobs:
         with:
           cache: build
           cache_ver: ${{ env.CACHE_VER }}
+          # Xcode selection matters on macos-15 images (the action's defaults,
+          # 14.3.1/15.0.1, are not installed there); null off-macOS, where the
+          # action falls back to its defaults and setup-xcode does not run.
+          xcode: ${{ matrix.env.xcode }}
           # Deps are ruby-independent, so the action's cache (keyed by tebako
           # hash) covers only .tebako/deps and is shared across ruby versions;
           # the ruby-specific press output is handled by the per-ruby cache above.

--- a/scripts/upload_release.rb
+++ b/scripts/upload_release.rb
@@ -28,6 +28,7 @@
 
 require "bundler/setup"
 require "octokit"
+require "digest"
 require "json"
 require "pathname"
 
@@ -43,6 +44,10 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
     @release_title = "Tebako runtime packages #{@tag}"
   end
 
+  def build_manifest_entries(packages)
+    packages.sort_by { |package| package.basename.to_s }.map { |package| manifest_entry(package) }
+  end
+
   def categorize_packages(filenames)
     sections = initialize_sections
     filenames.each do |filename|
@@ -50,6 +55,33 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
       sections[platform] << filename if platform
     end
     sections
+  end
+
+  def expected_package_names
+    env_json = ENV.fetch("EXPECTED_ENV_MATRIX", nil)
+    ruby_json = ENV.fetch("EXPECTED_RUBY_MATRIX", nil)
+    return [] unless env_json && ruby_json
+
+    envs = JSON.parse(env_json)
+    rubies = JSON.parse(ruby_json)
+    envs.product(rubies).map { |env, ruby| "tebako-runtime-#{@version}-#{ruby}-#{env["os"]}-#{env["arch"]}" }
+  rescue JSON::ParserError => e
+    puts "::warning::Could not compute expected package list: #{e.message}"
+    []
+  end
+
+  # Metadata files (SHA256SUMS.txt, manifest.json) are always overwritten,
+  # regardless of FORCE_REBUILD, so they never go stale on partial releases.
+  def force_upload(release, file)
+    filename = file.basename.to_s
+    remove_existing_asset(release, filename) if release.assets.find { |a| a.name == filename }
+    perform_upload(release, file, filename)
+  end
+
+  def generate_manifest(entries)
+    path = Pathname.new("manifest.json")
+    path.write("#{JSON.pretty_generate(entries)}\n")
+    path
   end
 
   def generate_release_notes(sections)
@@ -64,6 +96,8 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
     sections.each do |platform, files|
       body += generate_section(platform, files)
     end
+    body += "\nChecksums: see the `SHA256SUMS.txt` asset.\n"
+    body += "Machine-readable package index: see the `manifest.json` asset.\n"
     body
   end
 
@@ -73,6 +107,12 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
     section = "\n### #{platform_display_name(platform)} executables\n"
     files.each { |file| section += "- #{file}\n" }
     section
+  end
+
+  def generate_sha256sums(entries)
+    path = Pathname.new("SHA256SUMS.txt")
+    path.write("#{entries.map { |entry| "#{entry[:sha256]}  #{entry[:filename]}" }.join("\n")}\n")
+    path
   end
 
   def get_or_create_release # rubocop:disable Naming/AccessorMethodName
@@ -87,6 +127,29 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
 
   def initialize_sections
     { "windows" => [], "macos" => [], "linux-gnu" => [], "linux-musl" => [] }
+  end
+
+  def manifest_entry(package)
+    filename = package.basename.to_s
+    ruby_version, platform = parse_package_filename(filename)
+    {
+      tebako_version: @version,
+      ruby_version: ruby_version,
+      platform: platform,
+      filename: filename,
+      sha256: Digest::SHA256.file(package).hexdigest,
+      size_bytes: package.size
+    }
+  end
+
+  def parse_package_filename(filename)
+    match = /\Atebako-runtime-#{Regexp.escape(@version)}-(\d+\.\d+\.\d+)-(.+?)(?:\.exe)?\z/.match(filename)
+    unless match
+      puts "::warning::Cannot infer ruby/platform from package filename: #{filename}"
+      return [nil, nil]
+    end
+
+    [match[1], match[2]]
   end
 
   def perform_upload(release, package, filename)
@@ -114,10 +177,22 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
     puts "Working with release ID: #{release.id}"
 
     packages = validate_packages_directory
+    report_missing_packages(packages)
     sections = upload_and_categorize(release, packages)
+    upload_metadata(release, packages)
     release_body = generate_release_notes(sections)
     @client.update_release(release.url, body: release_body)
     puts "Successfully updated release notes"
+  end
+
+  def report_missing_packages(packages)
+    found = packages.map { |package| package.basename.to_s.sub(/\.exe\z/, "") }
+    missing = expected_package_names - found
+    return if missing.empty?
+
+    puts "::warning::Release incomplete: #{missing.size} expected runtime package(s) are missing"
+    missing.sort.each { |name| puts "::warning::Missing runtime package: #{name}" }
+    puts "Continuing release update with #{found.size} available package(s)"
   end
 
   def remove_existing_asset(release, filename)
@@ -137,6 +212,14 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
   def upload_and_categorize(release, packages)
     uploaded_files = packages.map { |package| upload_package(release, package) }
     categorize_packages(uploaded_files)
+  end
+
+  def upload_metadata(release, packages)
+    entries = build_manifest_entries(packages)
+    [generate_sha256sums(entries), generate_manifest(entries)].each do |file|
+      puts "Uploading metadata file #{file.basename} (always overwritten)"
+      force_upload(release, file)
+    end
   end
 
   def upload_package(release, package)


### PR DESCRIPTION
## Summary

Hardens the release pipeline (all five items in one PR):

1. **PR-event guard** — the `release` job now has `if: always() && !cancelled() && github.event_name != 'pull_request'`: it can never touch the production release from a pull request.
2. **Tolerant release** — `always()` minus cancelled replaces `success()`: one failing platform no longer nukes the entire release. The release uploads whatever artifacts exist, and `scripts/upload_release.rb` loudly warns (`::warning::` annotations) about every expected-but-missing package (expected set = env-matrix × ruby-matrix passed in from the `prepare` job). Build jobs themselves are unchanged/strict.
3. **SHA256SUMS + manifest.json** — `upload_release.rb` now computes SHA256 for every runtime package, writes standard-format `SHA256SUMS.txt` and a machine-readable `manifest.json` (array of `{tebako_version, ruby_version, platform, filename, sha256, size_bytes}`, ruby/platform inferred from the filename incl. optional `.exe`), uploads both to the release **always overwriting** (FORCE_REBUILD-independent), and references them in the release body.
4. **Parallel matrix** — `build` job now matrices over `env × ruby` (one ruby per job; ~84 jobs on the full matrix, 14 on the PR tidy matrix). Per-(platform, ruby, tebako-version) `actions/cache@v4` on `.tebako` for host-native jobs; the `setup-tebako` action cache is narrowed to `.tebako/deps` (ruby-independent, shared across rubies). Container jobs cannot be cached host-side — their deps are baked into the CI container image (documented in the workflow).
5. **Runner refresh** — `macos-13` → `macos-15-intel` (x86_64), `macos-14` → `macos-15` (arm64).

## Validation

- `ruby -ryaml` on the workflow, `ruby -c` on both scripts, JSON parse of `matrix.json`: all OK
- `rubocop scripts/`: no new offenses (3 pre-existing offenses on main unchanged)
- Smoke-tested the new `upload_release.rb` logic locally (fake packages incl. `.exe` suffix and a stray file): checksums, manifest fields, missing-package warnings, release-body references all verified