### PR TITLE
ci: prebuilt libtfs on musl-arm64 (v0.12.9); windows legs advisory

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -96,6 +96,11 @@ jobs:
     name: Build runtime package for ${{ matrix.env.os }} / ${{ matrix.env.arch }} / Ruby ${{ matrix.ruby }}
     needs: prepare
     runs-on: ${{ matrix.env.host }}
+    # Windows legs are advisory: the Ruby build on UCRT64 is broken upstream
+    # (win32.c clock_gettime/clock_getres collide with modern winpthreads
+    # headers; tebako's own windows-msys CI has been red for months). The
+    # release job runs always() and publishes the POSIX packages.
+    continue-on-error: ${{ matrix.env.os == 'windows' }}
     strategy:
       fail-fast: false
       matrix:
@@ -130,13 +135,7 @@ jobs:
           container="ghcr.io/tamatebako/tebako-${{ matrix.env.container }}:${{ needs.prepare.outputs.tebako-version }}"
           echo "Building runtime for Ruby ${{ matrix.ruby }} on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
           runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-${{ matrix.ruby }}-${{ matrix.env.os }}-${{ matrix.env.arch }}"
-          # musl-arm64 has no prebuilt libtfs package yet (first ships in
-          # libtfs v0.12.9); build the engine from source on those legs
-          PRELOAD_FLAG=""
-          if [ "${{ matrix.env.os }}" = "linux-musl" ] && [ "${{ matrix.env.arch }}" = "arm64" ]; then
-            PRELOAD_FLAG="-e DWARFS_PRELOAD=OFF"
-          fi
-          docker run -v ${{github.workspace}}:/mnt/w $PRELOAD_FLAG -t $container \
+          docker run -v ${{github.workspace}}:/mnt/w -t $container \
             tebako press -m runtime -o="/mnt/w/runtime-packages/$runtime" -R=${{ matrix.ruby }} ${{ matrix.env.os == 'linux-gnu' && '--patchelf' || '' }}
 
       - name: Setup MSys

--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -130,7 +130,13 @@ jobs:
           container="ghcr.io/tamatebako/tebako-${{ matrix.env.container }}:${{ needs.prepare.outputs.tebako-version }}"
           echo "Building runtime for Ruby ${{ matrix.ruby }} on ${{ matrix.env.os }}/${{ matrix.env.arch }}"
           runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-${{ matrix.ruby }}-${{ matrix.env.os }}-${{ matrix.env.arch }}"
-          docker run -v ${{github.workspace}}:/mnt/w -t $container \
+          # musl-arm64 has no prebuilt libtfs package yet (first ships in
+          # libtfs v0.12.9); build the engine from source on those legs
+          PRELOAD_FLAG=""
+          if [ "${{ matrix.env.os }}" = "linux-musl" ] && [ "${{ matrix.env.arch }}" = "arm64" ]; then
+            PRELOAD_FLAG="-e DWARFS_PRELOAD=OFF"
+          fi
+          docker run -v ${{github.workspace}}:/mnt/w $PRELOAD_FLAG -t $container \
             tebako press -m runtime -o="/mnt/w/runtime-packages/$runtime" -R=${{ matrix.ruby }} ${{ matrix.env.os == 'linux-gnu' && '--patchelf' || '' }}
 
       - name: Setup MSys


### PR DESCRIPTION
## What

- **Reverts the musl-arm64 `DWARFS_PRELOAD=OFF` source-build fallback** (#8): libtfs v0.12.9 now ships `linux-musl-arm64` prebuilt packages (`libtfs`, `libtfs-deps`, `mkdwarfs`, `tebakofs`) and tebako pins v0.12.9 as of tamatebako/tebako@6c4a95b, so musl-arm64 uses the same fast prebuilt path as every other platform. No more vcpkg source builds in the alpine container.
- **Windows legs become `continue-on-error`** with a pointer to tamatebako/tebako#345 (UCRT64 `clock_gettime`/`clock_getres` redefinition; pre-existing — tebako's windows-msys CI has been red for months). The release job runs `always()` and publishes the POSIX packages; missing windows packages are reported as warnings.

## Merge timing

Merge after tebako gem **0.15.2** is published (the musl-arm64 prebuilt path requires the v0.12.9 pin; `prepare` resolves the latest gem at run time).

## Test plan

- [ ] PR run (tidy matrix) builds all POSIX legs via the prebuilt path
- [ ] Post-0.15.2 dispatch produces musl-arm64 runtime packages without the fallback