### PR TITLE
ci: slice dispatches — env/ruby filters, cross-run artifact folding

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -45,9 +45,27 @@ on:
         description: 'Force rebuild and overwrite existing runtime packages'
         type: boolean
         default: false
+      env_filter:
+        description: 'Platform slice: "all" or "<os>/<arch>" (e.g. "linux-musl/arm64")'
+        type: string
+        default: 'all'
+      ruby_filter:
+        description: 'Rubies: "full", "tidy", or comma-separated versions (e.g. "3.3.7,3.4.2")'
+        type: string
+        default: 'full'
+      publish:
+        description: 'Run the release job (add this run''s packages to the release)'
+        type: boolean
+        default: true
+      artifact_run_ids:
+        description: 'Extra run IDs (comma-separated) whose runtime-packages-* artifacts join the release'
+        type: string
+        default: ''
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  # Slice dispatches (env/ruby filters) get their own group so a debugging
+  # slice never cancels the full build (or another slice) on the same ref
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}${{ github.event_name == ''workflow_dispatch'' && format(''-{0}-{1}'', inputs.env_filter, inputs.ruby_filter) || '''' }}'
   cancel-in-progress: true
 
 permissions:
@@ -89,6 +107,8 @@ jobs:
         id: set-matrix
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          MATRIX_ENV_FILTER: ${{ inputs.env_filter || '' }}
+          MATRIX_RUBY_FILTER: ${{ inputs.ruby_filter || '' }}
         run: |
           ./scripts/generate_matrix.rb
 
@@ -197,8 +217,9 @@ jobs:
     # Never touch the production release from a pull request; otherwise run
     # whenever the run was not cancelled, even if some build matrix legs
     # failed (upload whatever artifacts exist; missing packages are reported
-    # loudly by scripts/upload_release.rb).
-    if: ${{ always() && !cancelled() && github.event_name != 'pull_request' }}
+    # loudly by scripts/upload_release.rb). Slice dispatches may opt out of
+    # publishing (publish=false) for pure debugging runs.
+    if: ${{ always() && !cancelled() && github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.publish) }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -213,6 +234,24 @@ jobs:
         with:
           path: runtime-packages
           merge-multiple: true
+
+      # Fold in artifacts produced by earlier runs (e.g. a cancelled full
+      # build) so a slice run can complete a release without rebuilding
+      # platforms it does not touch. Current-run packages win on name
+      # collisions (cp -n).
+      - name: Download runtime packages from additional runs
+        if: inputs.artifact_run_ids != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_IDS: ${{ inputs.artifact_run_ids }}
+        run: |
+          set -euo pipefail
+          for rid in ${RUN_IDS//,/ }; do
+            echo "Fetching runtime-packages-* artifacts from run $rid"
+            gh run download "$rid" --repo tamatebako/tebako-runtime-ruby \
+              -p 'runtime-packages-*' -D "runtime-packages-runs/$rid" --clobber
+          done
+          find runtime-packages-runs -type f -exec cp -n {} runtime-packages/ \;
 
       - name: Setup Ruby gems
         uses: ruby/setup-ruby@v1

--- a/scripts/generate_matrix.rb
+++ b/scripts/generate_matrix.rb
@@ -53,6 +53,7 @@ class MatrixGenerator
   def process_env_matrix(data)
     @logger.info("Processing environment matrix...")
     env = validate_json_section(data, "env")
+    env = filter_env(env)
     @logger.info("Generated env matrix:")
     @logger.info(JSON.pretty_generate(env))
     write_output("env-matrix", env)
@@ -63,12 +64,38 @@ class MatrixGenerator
     raise
   end
 
+  # Optional slice filter for workflow_dispatch iteration/debugging:
+  # MATRIX_ENV_FILTER="linux-musl/arm64" selects a single os/arch pair
+  # ("all" or empty keeps every entry)
+  def filter_env(env)
+    filter = ENV.fetch("MATRIX_ENV_FILTER", "")
+    return env if filter.empty? || filter == "all"
+
+    os, arch = filter.split("/", 2)
+    selected = env.select { |e| e["os"] == os && (arch.nil? || arch.empty? || e["arch"] == arch) }
+    raise "MATRIX_ENV_FILTER '#{filter}' matched no env entries" if selected.empty?
+
+    @logger.info("MATRIX_ENV_FILTER '#{filter}' selected #{selected.size} env entry(ies)")
+    selected
+  end
+
+  # MATRIX_RUBY_FILTER: "full"/"tidy" select the named matrix.json set; a
+  # comma-separated version list ("3.3.7,3.4.2") overrides for slice
+  # dispatches; empty falls back to the event-based default
+  def select_ruby_versions(data)
+    filter = ENV.fetch("MATRIX_RUBY_FILTER", "")
+    return get_ruby_versions(data, filter) if %w[full tidy].include?(filter)
+    return filter.split(",").map(&:strip).reject(&:empty?) unless filter.empty?
+
+    suffix = determine_ruby_suffix
+    get_ruby_versions(data, suffix)
+  end
+
   def process_ruby_matrix(data)
     @logger.info("Processing ruby matrix...")
-    suffix = determine_ruby_suffix
-    ruby_versions = get_ruby_versions(data, suffix)
+    ruby_versions = select_ruby_versions(data)
 
-    @logger.info("Generated ruby matrix for #{suffix}: #{JSON.pretty_generate(ruby_versions)}")
+    @logger.info("Generated ruby matrix: #{JSON.pretty_generate(ruby_versions)}")
     write_output("ruby-matrix", ruby_versions)
   rescue StandardError => e
     @logger.error("Error processing ruby matrix: #{e.message}")


### PR DESCRIPTION
## Why

The v0.15.2 full-matrix run exposed the cost of the monolith: 72 legs finished (60 POSIX green, 12 windows failed-advisory) while 12 musl-arm64 legs ran 2+ hours with no visibility (logs are gated until run completion), and cancelling stranded 60 good legs' artifacts with no path to complete the release.

## What

`workflow_dispatch` gains four inputs:

| input | purpose | example |
|---|---|---|
| `env_filter` | build one platform slice | `linux-musl/arm64` |
| `ruby_filter` | `full`/`tidy`/comma list | `3.3.7` |
| `artifact_run_ids` | fold prior runs' `runtime-packages-*` artifacts into this run's release (current run wins collisions) | `30010206636` |
| `publish` | `false` = skip the release job (pure debugging) | — |

Slice dispatches also get their own concurrency group so they never cancel the full build or each other.

## Test plan

- [x] `generate_matrix.rb` locally: empty/all = full matrix, `linux-musl/arm64` = 1 entry, bogus = loud error, comma list = exact versions, PR event still tidy
- [x] workflow YAML parses
- [ ] PR run (tidy matrix) green
- [ ] post-merge: single-leg musl-arm64 debugging dispatch