### PR TITLE
Fully-modern runtime: libtfs v0.13.0 x tfs-ruby src v0.1.3

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -188,8 +188,10 @@ string(SUBSTRING ${RUBY_VER} 0 3 RUBY_VER_BASE)
 string(CONCAT RUBY_API_VER ${RUBY_VER_BASE} ".0")
 
 # libtfs (former libdwarfs-wr): DWARFS_WR_TAG selects the libtfs git tag for
-# the source build and the matching GitHub release for the prebuilt package
-def_ext_prj_g(DWARFS_WR "v0.12.10")
+# the source build and the matching GitHub release for the prebuilt package.
+# v0.13.0: the legacy tebako C/C++ API is fully removed (modern tebako_fs_*
+# only) and the pure-C dirent helper is merged into libtfs.a.
+def_ext_prj_g(DWARFS_WR "v0.13.0")
 
 # Provisions libtfs (prebuilt package or vcpkg toolchain for the source
 # build), the prebuilt mkdwarfs, and -- for the prebuilt path -- the
@@ -316,12 +318,11 @@ configure_file(${CMAKE_SOURCE_DIR}/resources/stub.rb.in ${GEN_DIR}/local/stub.rb
 
 # ...................................................................
 # The libraries provided by libtfs (prebuilt package or source build):
-# libtfs.a plus its pure-C dirent helper. These forward-declarations and
-# BUILD_BYPRODUCTS are required to support 'Ninja'
+# libtfs.a (v0.13.0 merges the former pure-C dirent helper). These
+# forward-declarations and BUILD_BYPRODUCTS are required to support 'Ninja'
 # Otherwise add_dependencies would be enough for 'Unix makefiles' generator
 
 set(__LIBTFS "${DEPS_LIB_DIR}/libtfs.a")
-set(__LIBTFS_HELPER "${DEPS_LIB_DIR}/libtebako_dirent_helper_c.a")
 
 if(DWARFS_PRELOAD)
   # Everything for the prebuilt path (download, SHA256 verification,
@@ -359,7 +360,6 @@ else(DWARFS_PRELOAD)
                ${LIBTFS_VCPKG_EP_TRIPLET_ARG}
                -GNinja
     BUILD_BYPRODUCTS ${__LIBTFS}
-                     ${__LIBTFS_HELPER}
   )
 endif(DWARFS_PRELOAD)
 

--- a/build/lib/tebako_runtime_builder/mlibs.rb
+++ b/build/lib/tebako_runtime_builder/mlibs.rb
@@ -44,7 +44,7 @@ module TebakoRuntimeBuilder
 
     DARWIN_BREW_LIBS_31 = [["openssl@3", "ssl"], ["openssl@3", "crypto"]].freeze
 
-    DARWIN_DEP_LIBS_1 = ["tfs", "tebako_dirent_helper_c"].freeze
+    DARWIN_DEP_LIBS_1 = ["tfs"].freeze
     # Referenced by full path from the vcpkg triplet lib dir (see
     # darwin_libraries): Apple ld does not implement the GNU-style
     # -l:<filename> library search, so -l:libX.a refs do not resolve.
@@ -58,14 +58,15 @@ module TebakoRuntimeBuilder
     # --start-group/--end-group around the libtfs + transitive static archives:
     # the dwarfs reader set has circular member-level references that trip GNU
     # ld's single-pass scanning when built with clang (compression registrar).
-    # libtfs (libtfs.a + its pure-C dirent helper) and the transitive static
-    # set resolved by vcpkg into deps/vcpkg_installed/<triplet>/lib: the
-    # dwarfs reader side, flatbuffers, zip and the C++ support libs.
+    # libtfs.a (v0.13.0: the legacy API is removed and the former pure-C
+    # dirent helper is merged in) and the transitive static set resolved by
+    # vcpkg into deps/vcpkg_installed/<triplet>/lib: the dwarfs reader side,
+    # flatbuffers, zip and the C++ support libs.
     # Compression codecs register explicitly (compression_registry ctor),
     # so no --whole-archive compression lib is needed anymore.
     COMMON_LINUX_LIBRARIES = [
       "-Wl,--push-state,--whole-archive -l:libtebako-fs.a -Wl,--pop-state",
-      "-l:libtfs.a", "-l:libtebako_dirent_helper_c.a",
+      "-l:libtfs.a",
       "-l:libdwarfs_reader.a", "-l:libdwarfs_common.a", "-l:libdwarfs_metadata_legacy.a",
       "-l:libdwarfs_decompressor.a", "-l:libflatbuffers.a", "-l:libzip.a",
       "-l:libfmt.a", "-l:libxxhash.a", "-l:libboost_filesystem.a",

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.1.2"
+    DEFAULT_RELEASE = "v0.1.3"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)

--- a/build/src/tebako-main.cpp
+++ b/build/src/tebako-main.cpp
@@ -68,14 +68,10 @@
 
 #include <string>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <vector>
 #include <stdexcept>
-/* <cstring> for std::memcpy/std::memcmp: pulled in transitively by libc++
-   (macOS) but not by the libstdc++ in the tebako CI containers (clang-18),
-   where the vendored file fails to compile without it. One-line divergence
-   from tamatebako/tebako@207d777 -- upstream candidate. */
-#include <cstring>
 
 #ifdef _WIN32
 #include <winsock2.h>

--- a/spec/mlibs_spec.rb
+++ b/spec/mlibs_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TebakoRuntimeBuilder::Mlibs do
     it "computes the group-wrapped static library list" do
       expected = "-Wl,--start-group " \
                  "-Wl,--push-state,--whole-archive -l:libtebako-fs.a -Wl,--pop-state " \
-                 "-l:libtfs.a -l:libtebako_dirent_helper_c.a " \
+                 "-l:libtfs.a " \
                  "-l:libdwarfs_reader.a -l:libdwarfs_common.a -l:libdwarfs_metadata_legacy.a " \
                  "-l:libdwarfs_decompressor.a -l:libflatbuffers.a -l:libzip.a " \
                  "-l:libfmt.a -l:libxxhash.a -l:libboost_filesystem.a -l:libboost_chrono.a " \
@@ -87,7 +87,7 @@ RSpec.describe TebakoRuntimeBuilder::Mlibs do
       # the gem's PatchLibraries produced them (the linker resolves them)
       vcpkg = File.join(root, "deps", "lib", "..", "vcpkg_installed", "arm64-osx", "lib")
       expected = "-ltebako-fs " \
-                 "#{root}/deps/lib/libtfs.a #{root}/deps/lib/libtebako_dirent_helper_c.a " \
+                 "#{root}/deps/lib/libtfs.a " \
                  "/brew/openssl@3/lib/libssl.a /brew/openssl@3/lib/libcrypto.a " \
                  "/brew/zlib/lib/libz.a /brew/gdbm/lib/libgdbm.a /brew/readline/lib/libreadline.a " \
                  "/brew/libffi/lib/libffi.a /brew/ncurses/lib/libncurses.a /brew/lz4/lib/liblz4.a " \


### PR DESCRIPTION
## What

First fully-modern runtime build: **libtfs v0.13.0 × tamatebako/ruby src v0.1.3**.

- **libtfs pin 0.12.10 → 0.13.0**: the legacy C/C++ API is fully removed (modern `tebako_fs_*` is the only surface) and the pure-C dirent helper is merged into `libtfs.a` — dropped `libtebako_dirent_helper_c.a` from the mlibs lists and the CMake byproducts (v0.13.0 consumption fix).
- **`SourceFetcher::DEFAULT_RELEASE` v0.1.2 → v0.1.3**: all io-routing patches call only `tebako_fs_*` (verified zero legacy refs in the 3.3.7 tree: io.c/dir.c/file.c patched with 39 `tebako_fs_*` call sites, no `tebako_open`/`tebako-io.h` anywhere).
- **Driver re-vendored from tamatebako/tebako@3ad6745** (the `<cstring>` fix landed upstream; the vendored copy is byte-identical again; `tebako-main.h`/`tebako-fs.h`/`tebako-prism.h`/`tpkg.h` confirmed in sync).

## Validation (macOS arm64, real release assets, sha256-verified)

- `tools/build_runtime --ruby 3.3.7` and `--ruby 4.0.6` → both `BUILD_EXIT=0`.
- nm on both binaries: **zero legacy references** (`tebako_open`/`tebako_stat`/`tebako_opendir`/`cmdline_args`/`package_descriptor` absent, no undefined tebako symbols); 23–24 `tebako_fs_*` symbols present including the six v0.13.0 additions (`tebako_fs_dir_is_embedded`, `rewinddir`, `telldir`, `seekdir`, `pread`, `dlmap2file`).
- 32 rspec examples, rubocop clean.

## Execution status + upstream blocker (tamatebako/ruby, agent-117)

Stock runtimes mount the incbin image and begin entry dispatch, but execution of any memfs script is blocked by a gap in the v0.1.3 io patches: the c_api hands out **virtual fds** (`TEBAKO_FD_FLAG=0x40000000`) and the shim set (`open/read/pread/lseek/close/fstat` in io.c; `stat/lstat/access/opendir/readdir/closedir/rewinddir/telldir/seekdir` in dir.c/file.c) has **no `fcntl` shim**, while ruby calls raw `fcntl` on the entry fd in two places:

1. `io.c: rb_fix_detect_o_cloexec` / `rb_maygvl_fd_fix_cloexec` → `[BUG] ... fcntl(0x40000001, F_GETFD) failed: Bad file descriptor` (crash).
2. `ruby.c: disable_nonblock` (`open_load_file`, currently unpatched on POSIX) → real `fcntl(fd, F_SETFL)` via PLT → `Bad file descriptor -- /__tebako_memfs__/local/stub.rb (LoadError)`.

Proven by a **local, non-shipped experiment** (io.c + ruby.c `tfs_fcntl` shims: embedded fds emulate `F_GETFD/F_SETFD/F_GETFL/F_SETFL`, everything else passes through). With both shims the fully-modern stack executes end-to-end:

```
$ ./tebako-runtime-0.15.9-3.3.7-macos-arm64
Copyright (c) 2024-2025 Ribose Inc (https://www.ribose.com)
Tebako runtime stub v0.15.9
To run your application please call tebako-runtime-0.15.9-3.3.7-macos-arm64 --tebako-run <your tebako package>

$ ./tebako-runtime-0.15.9-3.3.7-macos-arm64 --tebako-run app.dwarfs
hello from the packaged app (ruby 3.3.7, arm64-darwin23)
Dir.entries(/local): ["hello.rb", "stub.rb"]
rewinddir round-trip: true
telldir/seekdir round-trip: true
IO#pread: "# Smoke applicat"
json ext (static): {"ok":true}
openssl ext (static): OpenSSL 3.6.3 9 Jun 2026
SMOKE OK
```

(The app image was assembled from the built runtime layout + `local/hello.rb` with a TAMATEBAKO descriptor via `mkdwarfs --header`.) The experiment is **not** part of this PR; the shim content is handed to the tamatebako/ruby owner (agent-117) — once it lands upstream (expected v0.1.4), only the `DEFAULT_RELEASE` bump is needed here.

Windows legs stay advisory (msys scenario src is item 20, built separately).
