### PR TITLE
chore: consume tamatebako/ruby src v0.2.1 — stock execution unlocked

### DIFF
--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.1.3"
+    DEFAULT_RELEASE = "v0.2.1"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)


### PR DESCRIPTION
One-line pin: SourceFetcher::DEFAULT_RELEASE v0.1.3 → v0.2.1 (carries the tfs_fcntl shim in io.c+ruby.c on all lines).

PROOF (all stock artifacts, macOS arm64): build_runtime --ruby 3.3.7 → BUILD_EXIT=0; nm: 0 legacy refs, 24 tebako_fs_* symbols; stock runtime + app image → --tebako-run → full smoke PASS:

hello from the packaged app (ruby 3.3.7, arm64-darwin23)
Dir.entries(/local): ["hello.rb", "stub.rb"]
rewinddir round-trip: true
telldir/seekdir round-trip: true
IO#pread: "# Smoke applicat"
json ext (static): {"ok":true}
openssl ext (static): OpenSSL 3.6.3 9 Jun 2026
SMOKE OK

Specs 32/32. This is the first fully-executable runtime on the stock modern stack (libtfs v0.13.0 × src v0.2.1 × driver 3ad6745) — zero legacy API anywhere.