### PR TITLE
Per-platform scenario consumption + msys two-pass flow (item 20b)

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -115,6 +115,14 @@ jobs:
     name: Build runtime package for ${{ matrix.env.os }} / ${{ matrix.env.arch }} / Ruby ${{ matrix.ruby }}
     needs: prepare
     runs-on: ${{ matrix.env.host }}
+    # Windows legs are advisory until the msys scenario source compiles on
+    # UCRT64: the v0.2.1 msys trees carry the full msys patch set but two
+    # compile bugs in the io-routing shims (tamatebako/ruby, not this repo):
+    # dir.c tfs_closedir returns the void rb_w32_closedir(), and the 4.x
+    # prism_compile.c shim uses O_RDONLY without <fcntl.h>. The consumer-side
+    # machinery (two-pass overlay flow) is proven up to those errors; the
+    # advisory flips off when a fixed scenario release lands.
+    continue-on-error: ${{ matrix.env.os == 'windows' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -115,11 +115,6 @@ jobs:
     name: Build runtime package for ${{ matrix.env.os }} / ${{ matrix.env.arch }} / Ruby ${{ matrix.ruby }}
     needs: prepare
     runs-on: ${{ matrix.env.host }}
-    # Windows legs are advisory: the Ruby build on UCRT64 is broken upstream
-    # (win32.c clock_gettime/clock_getres collide with modern winpthreads
-    # headers; tebako's own windows-msys CI has been red for months). The
-    # release job runs always() and publishes the POSIX packages.
-    continue-on-error: ${{ matrix.env.os == 'windows' }}
     strategy:
       fail-fast: false
       matrix:

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -179,6 +179,13 @@ if ("-${RUBY_VER}" STREQUAL "-" OR "-${RUBY_HASH}" STREQUAL "-" OR "-${RUBY_TARB
   message(FATAL_ERROR "Ruby version, source tarball and its SHA256 must be specified (RUBY_VER, RUBY_TARBALL, RUBY_HASH)")
 endif()
 
+# msys consumes the two-pass scenario source: the pass-1 tarball drives the
+# main tree (toolchain build); the pass-2 tree (final-build GNUmakefile.in
+# variant) is overlaid after the toolchain stage.
+if(IS_MSYS AND ("-${RUBY_TARBALL_P2}" STREQUAL "-" OR "-${RUBY_HASH_P2}" STREQUAL "-"))
+  message(FATAL_ERROR "msys builds need the pass-2 source tarball and its SHA256 (RUBY_TARBALL_P2, RUBY_HASH_P2)")
+endif()
+
 set(RUBY_PRJ _ruby_${RUBY_VER})
 set(RUBY_SOURCE_DIR ${DEPS}/src/${RUBY_PRJ})
 set(RUBY_BINARY_DIR ${DEPS}/src/${RUBY_PRJ})
@@ -457,8 +464,17 @@ message(STATUS "libyaml Ruby option='${LIBYAML_RUBY_OPTION}'")
 #   prepare       -- substitute @TEBAKO_MLIBS@ in template/Makefile.in and
 #                    build the stub libtebako-fs.a for the toolchain link
 #   postconfigure -- substitute S["MAINLIBS"] in the generated config.status
-#   toolchain     -- make + make install, stash the pristine environment,
-#                    drop the stub libtebako-fs.a
+#   toolchain     -- make + make install, stash the pristine environment
+#   overlay       -- (msys only) lay the pass-2 source tree onto the built
+#                    pass-1 tree, then re-run prepare for the substituted
+#                    files the overlay restored
+set(RUBY_PASS2_COMMANDS "")
+if(IS_MSYS)
+  set(RUBY_PASS2_COMMANDS
+    COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb overlay ${RUBY_TARBALL_P2} ${RUBY_HASH_P2} ${RUBY_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb prepare ${OSTYPE_TXT} ${RUBY_SOURCE_DIR} ${DEPS_LIB_DIR} ${RUBY_VER} ${FS_MOUNT_POINT} "${CMAKE_C_COMPILER}"
+  )
+endif()
 ExternalProject_Add(${RUBY_PRJ}
   PREFIX ${DEPS}
   URL ${RUBY_TARBALL}
@@ -484,6 +500,7 @@ ExternalProject_Add(${RUBY_PRJ}
                                                         LIBS=\"${RUBY_LIBS}\""
   COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb postconfigure ${OSTYPE_TXT} ${RUBY_SOURCE_DIR} ${DEPS_LIB_DIR} ${RUBY_VER}
   COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb toolchain ${RUBY_SOURCE_DIR} ${DATA_SRC_DIR} ${RUBY_STASH_DIR} ${DEPS_LIB_DIR}
+  ${RUBY_PASS2_COMMANDS}
   INSTALL_COMMAND  ""
 )
 
@@ -505,7 +522,7 @@ set(CMAKE_CXX_EXTENSIONS   OFF)
 # Packaged filesystem
 
 add_custom_target(packaged_filesystem
-  COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb deploy ${RUBY_VER} ${RUBY_STASH_DIR} ${DATA_SRC_DIR} ${DATA_PRE_DIR} ${DATA_BIN_FILE} ${GEN_DIR}/local ${DEPS_BIN_DIR}
+  COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb deploy ${RUBY_VER} ${RUBY_STASH_DIR} ${DATA_SRC_DIR} ${DATA_PRE_DIR} ${DATA_BIN_FILE} ${GEN_DIR}/local ${DEPS_BIN_DIR} ${RUBY_SOURCE_DIR} ${RUNTIME_NAME}
   DEPENDS setup
   BYPRODUCTS ${DATA_BIN_FILE}
 )

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+require "digest"
 require "fileutils"
 
 module TebakoRuntimeBuilder
@@ -79,7 +80,7 @@ module TebakoRuntimeBuilder
         substitute_config_status!(File.join(ruby_source_dir, "config.status"), platform, mlibs)
       end
 
-      def toolchain(ruby_source_dir, data_src_dir, stash_dir, deps_lib_dir) # rubocop:disable Metrics/MethodLength
+      def toolchain(ruby_source_dir, data_src_dir, stash_dir, deps_lib_dir) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
         puts "-- Running toolchain script"
 
         platform = TebakoRuntimeBuilder::Platform.new
@@ -117,23 +118,47 @@ module TebakoRuntimeBuilder
         FileUtils.cp_r "#{data_src_dir}/.", stash_dir
 
         # The stub driver served the toolchain link; the final relink must
-        # resolve -ltebako-fs to the real library in the CMake binary dir
-        FileUtils.rm_f(File.join(deps_lib_dir, "libtebako-fs.a"))
+        # resolve -ltebako-fs to the real library in the CMake binary dir.
+        # On msys the pass-2 overlay build still links against the stub, so
+        # it is removed by the finalize pass there instead.
+        FileUtils.rm_f(File.join(deps_lib_dir, "libtebako-fs.a")) unless platform.msys?
       end
 
-      def deploy(ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, stub_dir, deps_bin_dir) # rubocop:disable Metrics/ParameterLists
+      # msys two-pass flow: overlay the pass-2 source tree (carrying the
+      # final-build GNUmakefile.in variant) onto the built pass-1 tree,
+      # replicating the gem's "pass2 patches onto the same tree" semantics
+      # without re-deriving the pass split. Only files whose content differs
+      # (today: cygwin/GNUmakefile.in alone) are replaced -- fresh mtimes, so
+      # make regenerates exactly what the pass change affects; pass-1 build
+      # artifacts (objects, the generated implib/exp/def files) are left
+      # alone. The tarball hash is re-verified before extraction.
+      def overlay(pass2_tarball, pass2_sha256, ruby_source_dir, work_dir)
+        puts "-- Running overlay script (msys pass-2 tree)"
+
+        verify_tarball!(pass2_tarball, pass2_sha256)
+        root = extract_overlay(pass2_tarball, work_dir)
+        puts "   ... overlaid #{overlay_differing_files(root, ruby_source_dir)} pass-2 file(s) onto #{ruby_source_dir}"
+      end
+
+      def deploy(ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, stub_dir, deps_bin_dir, # rubocop:disable Metrics/ParameterLists
+                 ruby_source_dir = nil, runtime_name = nil)
         rv = TebakoRuntimeBuilder::RubyVersion.new(ruby_ver)
         platform = TebakoRuntimeBuilder::Platform.new
         TebakoRuntimeBuilder::ImageBuilder.new(platform, rv, stash_dir, data_src_dir, data_pre_dir,
                                                data_bin_file, deps_bin_dir).build(stub_dir)
+        create_implib(ruby_source_dir, data_src_dir, runtime_name, rv) if platform.msys?
       end
 
-      def finalize(ostype, ruby_source_dir, output, ruby_ver, patchelf = nil) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      def finalize(ostype, ruby_source_dir, output, ruby_ver, deps_lib_dir, patchelf = nil) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/ParameterLists
         puts "-- Running finalize script"
 
         platform = TebakoRuntimeBuilder::Platform.new(ostype)
         rv = TebakoRuntimeBuilder::RubyVersion.new(ruby_ver)
         rbconfig = File.join(ruby_source_dir, "rbconfig.rb")
+        # Drop the stub driver (the toolchain pass removed it already
+        # everywhere except msys): the relink must resolve -ltebako-fs to the
+        # real library in the CMake binary dir
+        FileUtils.rm_f(File.join(deps_lib_dir, "libtebako-fs.a"))
         Dir.chdir(ruby_source_dir) do
           # Flip the generated rbconfig.rb back to the memfs mount point so
           # the final ruby program links with the packaged load paths
@@ -242,6 +267,66 @@ module TebakoRuntimeBuilder
 
         params = [patchelf, "--remove-needed-version", "libpthread.so.0", "GLIBC_PRIVATE", src_name]
         TebakoRuntimeBuilder::BuildHelpers.run_with_capture(params)
+      end
+
+      def verify_tarball!(tarball, sha256)
+        actual = Digest::SHA256.file(tarball).hexdigest
+        return if actual == sha256
+
+        raise TebakoRuntimeBuilder::Error.new(
+          "#{File.basename(tarball)}: expected SHA256 #{sha256}, got #{actual}", 121
+        )
+      end
+
+      def extract_overlay(pass2_tarball, work_dir)
+        overlay_src = File.join(work_dir, "overlay-src")
+        FileUtils.rm_rf(overlay_src, secure: true)
+        FileUtils.mkdir_p(overlay_src)
+        TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["tar", "-xzf", pass2_tarball, "-C", overlay_src])
+        root = Dir.children(overlay_src).map { |child| File.join(overlay_src, child) }
+                                        .find { |path| File.directory?(path) }
+        raise TebakoRuntimeBuilder::Error.new("overlay tarball carries no source tree", 130) if root.nil?
+
+        root
+      end
+
+      def overlay_differing_files(root, ruby_source_dir)
+        replaced = 0
+        Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH).each do |src|
+          next unless File.file?(src)
+
+          dest = File.join(ruby_source_dir, src.delete_prefix("#{root}/"))
+          next if File.file?(dest) && FileUtils.compare_file(src, dest)
+
+          FileUtils.mkdir_p(File.dirname(dest))
+          FileUtils.cp(src, dest)
+          replaced += 1
+        end
+        replaced
+      end
+
+      # msys only: the import library the packaged mkmf-driven gem extensions
+      # link against (gem Packager.create_implib). tebako.def was generated
+      # by the pass-1 build's dlltool exp rule; the DllMain entry is dropped
+      # from the per-package def file.
+      def create_implib(src_dir, data_src_dir, app_name, ruby_ver)
+        a_name = File.basename(app_name, ".*")
+        puts "   ... creating Windows import library for #{a_name}.exe"
+        def_file = create_def(src_dir, a_name)
+        params = ["dlltool", "-d", def_file, "-D", "#{a_name}.exe", "--output-lib",
+                  File.join(data_src_dir, "lib", "libx64-ucrt-ruby#{ruby_ver.lib_version}.a")]
+        TebakoRuntimeBuilder::BuildHelpers.run_with_capture(params)
+      end
+
+      def create_def(src_dir, app_name)
+        def_file = File.join(src_dir, "#{app_name}.def")
+        File.open(def_file, "w") do |file|
+          file.puts "LIBRARY #{app_name}.exe"
+          File.readlines(File.join(src_dir, "tebako.def")).each do |line|
+            file.puts line unless line.include?("DllMain")
+          end
+        end
+        def_file
       end
 
       # With the common.mk exts.mk/extinit.c dependency present from the

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -62,8 +62,14 @@ module TebakoRuntimeBuilder
 
         platform = TebakoRuntimeBuilder::Platform.new(ostype)
         rv = TebakoRuntimeBuilder::RubyVersion.new(ruby_ver)
-        mlibs = TebakoRuntimeBuilder::Mlibs.new(platform, deps_lib_dir).compute(rv, with_compression: true)
-        substitute_tebako_mlibs!(File.join(ruby_source_dir, "template", "Makefile.in"), mlibs)
+        # The @TEBAKO_MLIBS@ template placeholder exists only in the
+        # linux-gnu/darwin/musl scenario trees; the msys scenario delivers
+        # MAINLIBS through the config.status substitution (postconfigure)
+        # instead, so there is no template substitution to make there.
+        unless platform.msys?
+          mlibs = TebakoRuntimeBuilder::Mlibs.new(platform, deps_lib_dir).compute(rv, with_compression: true)
+          substitute_tebako_mlibs!(File.join(ruby_source_dir, "template", "Makefile.in"), mlibs)
+        end
         build_toolchain_stub(platform, deps_lib_dir, mount_point, cc)
       end
 

--- a/build/lib/tebako_runtime_builder/builder.rb
+++ b/build/lib/tebako_runtime_builder/builder.rb
@@ -48,10 +48,11 @@ module TebakoRuntimeBuilder
     end
 
     def run
-      tarball, sha256 = fetcher.fetch(@ruby_version)
+      assets = fetcher.fetch_assets(@ruby_version, @platform)
       puts "-- Building tebako runtime for ruby #{@ruby_version} " \
-           "(tebako #{@tebako_version}, #{@platform.host_id})"
-      cmake_configure(tarball, sha256)
+           "(tebako #{@tebako_version}, #{@platform.host_id}, " \
+           "#{assets.map { |path,| File.basename(path) }.join(" + ")})"
+      cmake_configure(assets)
       cmake_build
       finalize
       @output
@@ -89,7 +90,8 @@ module TebakoRuntimeBuilder
       @jobs || @platform.ncores
     end
 
-    def cmake_configure(tarball, sha256) # rubocop:disable Metrics/MethodLength
+    def cmake_configure(assets) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      (tarball, sha256) = assets[0]
       args = ["cmake",
               "-DCMAKE_BUILD_TYPE=Release",
               "-DRUBY_VER:STRING=#{@ruby_version}",
@@ -99,6 +101,10 @@ module TebakoRuntimeBuilder
               "-DDEPS:STRING=#{deps}",
               "-DTEBAKO_VERSION:STRING=#{@tebako_version}",
               "-DLOG_LEVEL:STRING=error"]
+      if assets.length == 2
+        (tarball_p2, sha256_p2) = assets[1]
+        args += ["-DRUBY_TARBALL_P2:STRING=file://#{tarball_p2}", "-DRUBY_HASH_P2:STRING=#{sha256_p2}"]
+      end
       args << "-DREMOVE_GLIBC_PRIVATE=ON" if @patchelf && @platform.linux_gnu?
       args += ["-G", @platform.m_files, "-B", output_folder, "-S", File.join(@repo_root, "build")]
 
@@ -118,7 +124,8 @@ module TebakoRuntimeBuilder
     def finalize
       FileUtils.mkdir_p(File.dirname(output))
       patchelf = @patchelf && @platform.linux_gnu? ? File.join(deps, "bin", "patchelf") : nil
-      TebakoRuntimeBuilder::BuildPasses.finalize(@platform.ostype, ruby_source_dir, output, @ruby_version, patchelf)
+      TebakoRuntimeBuilder::BuildPasses.finalize(@platform.ostype, ruby_source_dir, output, @ruby_version,
+                                                 File.join(deps, "lib"), patchelf)
     end
   end
 end

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -50,9 +50,38 @@ module TebakoRuntimeBuilder
       "tfs-ruby-#{ruby_version}-src.tar.gz"
     end
 
+    # Per-platform scenario asset naming on tamatebako/ruby releases (item
+    # 20): the linux-gnu scenario ships unsuffixed for back-compat
+    # (tfs-ruby-<v>-src.tar.gz, proven correct for gnu AND macos runtimes);
+    # musl and msys ship their own scenarios. msys needs TWO trees -- the
+    # GNUmakefile.in pass split (pass1: toolchain build with the implib/exp
+    # generation rule active; pass2: the final build) -- which the consumer
+    # must not re-derive.
+    def self.scenario_asset_names(ruby_version, platform)
+      base = "tfs-ruby-#{ruby_version}-src"
+      if platform.msys?
+        ["#{base}-msys-pass1.tar.gz", "#{base}-msys-pass2.tar.gz"]
+      elsif platform.musl?
+        ["#{base}-linux-musl.tar.gz"]
+      else
+        ["#{base}.tar.gz"]
+      end
+    end
+
+    # Fetch every scenario asset the target platform needs; returns an array
+    # of [tarball_path, sha256] pairs (one for gnu/macos/musl, two for msys:
+    # pass1 then pass2).
+    def fetch_assets(ruby_version, platform)
+      self.class.scenario_asset_names(ruby_version, platform).map { |name| fetch_asset(name) }
+    end
+
     # Returns [tarball_path, sha256] for the requested ruby version
-    def fetch(ruby_version) # rubocop:disable Metrics/MethodLength
-      name = asset_name(ruby_version)
+    def fetch(ruby_version)
+      fetch_asset(asset_name(ruby_version))
+    end
+
+    # Returns [tarball_path, sha256] for the named release asset
+    def fetch_asset(name) # rubocop:disable Metrics/MethodLength
       sha256 = expected_sha256(name)
       tarball = File.join(@cache_dir, @release, name)
       return [tarball, sha256] if File.file?(tarball) && Digest::SHA256.file(tarball).hexdigest == sha256

--- a/build/resources/toolchain_stub.c
+++ b/build/resources/toolchain_stub.c
@@ -26,6 +26,8 @@
 #error "TEBAKO_STUB_MOUNT_POINT must be defined (the memfs mount point)"
 #endif
 
+#include <sys/types.h>
+
 int tebako_main(int *argc, char ***argv)
 {
     (void)argc;
@@ -46,4 +48,15 @@ int tebako_is_running_miniruby(void)
 const char *tebako_original_pwd(void)
 {
     return "";
+}
+
+/* Referenced by the ruby < 3.3 msys builds (the real driver provides it
+   under RB_W32_PRE_33); harmless elsewhere */
+ssize_t rb_w32_pread(int fd, void *buf, size_t size, size_t offset)
+{
+    (void)fd;
+    (void)buf;
+    (void)size;
+    (void)offset;
+    return -1;
 }

--- a/build/tools/build_pass.rb
+++ b/build/tools/build_pass.rb
@@ -78,23 +78,37 @@ begin
     #       ARGV[5] -- DATA_BIN_FILE
     #       ARGV[6] -- STUB_DIR
     #       ARGV[7] -- DEPS_BIN_DIR
-    unless ARGV.length == 8
+    #       ARGV[8] -- RUBY_SOURCE_DIR (msys implib)
+    #       ARGV[9] -- RUNTIME_NAME (msys implib)
+    unless ARGV.length == 10
       raise TebakoRuntimeBuilder::Error,
-            "build_pass deploy command expects 8 arguments, #{ARGV.length} has been provided."
+            "build_pass deploy command expects 10 arguments, #{ARGV.length} has been provided."
     end
-    TebakoRuntimeBuilder::BuildPasses.deploy(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6], ARGV[7])
+    TebakoRuntimeBuilder::BuildPasses.deploy(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6], ARGV[7],
+                                             ARGV[8], ARGV[9])
+  when "overlay"
+    #       ARGV[1] -- PASS2_TARBALL
+    #       ARGV[2] -- PASS2_SHA256
+    #       ARGV[3] -- RUBY_SOURCE_DIR
+    #       ARGV[4] -- WORK_DIR
+    unless ARGV.length == 5
+      raise TebakoRuntimeBuilder::Error,
+            "build_pass overlay command expects 5 arguments, #{ARGV.length} has been provided."
+    end
+    TebakoRuntimeBuilder::BuildPasses.overlay(ARGV[1], ARGV[2], ARGV[3], ARGV[4])
   when "finalize"
     #       ARGV[1] -- OSTYPE
     #       ARGV[2] -- RUBY_SOURCE_DIR
     #       ARGV[3] -- OUTPUT
     #       ARGV[4] -- RUBY_VER
-    #       ARGV[5] -- patchelf path (optional, "none" to skip)
-    unless [5, 6].include?(ARGV.length)
+    #       ARGV[5] -- DEPS_LIB_DIR
+    #       ARGV[6] -- patchelf path (optional, "none" to skip)
+    unless [6, 7].include?(ARGV.length)
       raise TebakoRuntimeBuilder::Error,
-            "build_pass finalize command expects 5 or 6 arguments, #{ARGV.length} has been provided."
+            "build_pass finalize command expects 6 or 7 arguments, #{ARGV.length} has been provided."
     end
-    patchelf = ARGV[5].nil? || ARGV[5] == "none" ? nil : ARGV[5]
-    TebakoRuntimeBuilder::BuildPasses.finalize(ARGV[1], ARGV[2], ARGV[3], ARGV[4], patchelf)
+    patchelf = ARGV[6].nil? || ARGV[6] == "none" ? nil : ARGV[6]
+    TebakoRuntimeBuilder::BuildPasses.finalize(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], patchelf)
   else
     raise TebakoRuntimeBuilder::Error, "build_pass cannot process #{ARGV[0]} command"
   end

--- a/spec/build_passes_spec.rb
+++ b/spec/build_passes_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
       expect { described_class.prepare("x86_64-linux-gnu", ruby_src, deps_lib_dir, "3.3.7", "/__tebako_memfs__", "cc") }
         .to raise_error(TebakoRuntimeBuilder::Error, /does not exist/)
     end
+
+    it "skips the template substitution on msys (MAINLIBS comes via config.status there)" do
+      File.write(File.join(ruby_src, "template", "Makefile.in"), "MAINLIBS = @MAINLIBS@\n")
+      expect do
+        described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+      end.not_to raise_error
+      expect(File.read(File.join(ruby_src, "template", "Makefile.in"))).to eq("MAINLIBS = @MAINLIBS@\n")
+      expect(File.file?(File.join(deps_lib_dir, "libtebako-fs.a"))).to be(true)
+    end
   end
 
   describe ".postconfigure" do

--- a/spec/build_passes_spec.rb
+++ b/spec/build_passes_spec.rb
@@ -95,4 +95,44 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
       end.to output(/Warning: no config.status MAINLIBS pattern matched/).to_stdout
     end
   end
+
+  describe ".overlay" do
+    let(:pass2_dir) { File.join(root, "pass2-tree", "tfs-ruby-3.3.7-src") }
+    let(:work_dir) { File.join(root, "work") }
+    let(:tarball) { File.join(root, "tfs-ruby-3.3.7-src-msys-pass2.tar.gz") }
+
+    before do
+      FileUtils.mkdir_p(File.join(pass2_dir, "cygwin"))
+      File.write(File.join(pass2_dir, "cygwin", "GNUmakefile.in"), "pass2 variant\n")
+      File.write(File.join(pass2_dir, "main.c"), "same content\n")
+
+      # the built pass-1 tree: one differing file, one identical file, one
+      # build artifact the overlay must preserve
+      FileUtils.mkdir_p(File.join(ruby_src, "cygwin"))
+      File.write(File.join(ruby_src, "cygwin", "GNUmakefile.in"), "pass1 variant\n")
+      File.write(File.join(ruby_src, "main.c"), "same content\n")
+      File.write(File.join(ruby_src, "tebako.def"), "EXPORTS\n  ruby_api\n")
+      File.write(File.join(ruby_src, "ruby.obj"), "object-bytes")
+
+      Dir.chdir(root) do
+        system("tar -czf #{tarball} -C pass2-tree tfs-ruby-3.3.7-src") || raise("tar failed")
+      end
+    end
+
+    it "replaces only content-differing files and preserves build artifacts" do
+      same_mtime = File.mtime(File.join(ruby_src, "main.c"))
+      sleep 0.05
+      described_class.overlay(tarball, Digest::SHA256.file(tarball).hexdigest, ruby_src, work_dir)
+
+      expect(File.read(File.join(ruby_src, "cygwin", "GNUmakefile.in"))).to eq("pass2 variant\n")
+      expect(File.mtime(File.join(ruby_src, "main.c"))).to eq(same_mtime)
+      expect(File.file?(File.join(ruby_src, "tebako.def"))).to be(true)
+      expect(File.binread(File.join(ruby_src, "ruby.obj"))).to eq("object-bytes")
+    end
+
+    it "rejects a tarball whose sha256 does not match" do
+      expect { described_class.overlay(tarball, "0" * 64, ruby_src, work_dir) }
+        .to raise_error(TebakoRuntimeBuilder::Error, /expected SHA256/)
+    end
+  end
 end

--- a/spec/source_fetcher_spec.rb
+++ b/spec/source_fetcher_spec.rb
@@ -59,4 +59,70 @@ RSpec.describe TebakoRuntimeBuilder::SourceFetcher do
   it "names assets per the tamatebako/ruby release contract" do
     expect(fetcher.asset_name("4.0.6")).to eq("tfs-ruby-4.0.6-src.tar.gz")
   end
+
+  describe ".scenario_asset_names" do
+    it "resolves the unsuffixed linux-gnu scenario for gnu and macos" do
+      expect(described_class.scenario_asset_names("3.3.7",
+                                                  TebakoRuntimeBuilder::Platform.new("x86_64-linux-gnu", "x86_64")))
+        .to eq(["tfs-ruby-3.3.7-src.tar.gz"])
+      expect(described_class.scenario_asset_names("3.3.7",
+                                                  TebakoRuntimeBuilder::Platform.new("arm64-darwin23", "arm64")))
+        .to eq(["tfs-ruby-3.3.7-src.tar.gz"])
+    end
+
+    it "resolves the musl scenario for linux-musl" do
+      expect(described_class.scenario_asset_names("3.3.7",
+                                                  TebakoRuntimeBuilder::Platform.new("x86_64-linux-musl", "x86_64")))
+        .to eq(["tfs-ruby-3.3.7-src-linux-musl.tar.gz"])
+    end
+
+    it "resolves the two-pass msys scenario for msys/mingw" do
+      expect(described_class.scenario_asset_names("3.3.7",
+                                                  TebakoRuntimeBuilder::Platform.new("x64-mingw-ucrt", "x86_64")))
+        .to eq(["tfs-ruby-3.3.7-src-msys-pass1.tar.gz", "tfs-ruby-3.3.7-src-msys-pass2.tar.gz"])
+    end
+  end
+
+  describe "#fetch_assets" do
+    before do
+      %w[tfs-ruby-3.3.7-src-linux-musl.tar.gz tfs-ruby-3.3.7-src-msys-pass1.tar.gz
+         tfs-ruby-3.3.7-src-msys-pass2.tar.gz].each do |name|
+        File.binwrite(File.join(mirror_dir, name), "content-of-#{name}")
+      end
+      File.write(File.join(mirror_dir, "SHA256SUMS"),
+                 ["#{sha256}  tfs-ruby-3.3.7-src.tar.gz",
+                  "#{Digest::SHA256.hexdigest("content-of-tfs-ruby-3.3.7-src-linux-musl.tar.gz")}  " \
+                  "tfs-ruby-3.3.7-src-linux-musl.tar.gz",
+                  "#{Digest::SHA256.hexdigest("content-of-tfs-ruby-3.3.7-src-msys-pass1.tar.gz")}  " \
+                  "tfs-ruby-3.3.7-src-msys-pass1.tar.gz",
+                  "#{Digest::SHA256.hexdigest("content-of-tfs-ruby-3.3.7-src-msys-pass2.tar.gz")}  " \
+                  "tfs-ruby-3.3.7-src-msys-pass2.tar.gz"].join("\n") << "\n")
+    end
+
+    it "fetches the single musl scenario asset, verified" do
+      platform = TebakoRuntimeBuilder::Platform.new("x86_64-linux-musl", "x86_64")
+      assets = fetcher.fetch_assets("3.3.7", platform)
+      expect(assets.length).to eq(1)
+      path, sum = assets[0]
+      expect(sum).to eq(Digest::SHA256.hexdigest("content-of-tfs-ruby-3.3.7-src-linux-musl.tar.gz"))
+      expect(File.binread(path)).to eq("content-of-tfs-ruby-3.3.7-src-linux-musl.tar.gz")
+    end
+
+    it "fetches both msys pass trees in order, each verified" do
+      platform = TebakoRuntimeBuilder::Platform.new("x64-mingw-ucrt", "x86_64")
+      assets = fetcher.fetch_assets("3.3.7", platform)
+      expect(assets.length).to eq(2)
+      expect(assets.map { |path,| File.basename(path) })
+        .to eq(["tfs-ruby-3.3.7-src-msys-pass1.tar.gz", "tfs-ruby-3.3.7-src-msys-pass2.tar.gz"])
+      expect(File.binread(assets[0][0])).to eq("content-of-tfs-ruby-3.3.7-src-msys-pass1.tar.gz")
+      expect(File.binread(assets[1][0])).to eq("content-of-tfs-ruby-3.3.7-src-msys-pass2.tar.gz")
+    end
+
+    it "fetches the unsuffixed asset for gnu" do
+      platform = TebakoRuntimeBuilder::Platform.new("x86_64-linux-gnu", "x86_64")
+      path, sum = fetcher.fetch_assets("3.3.7", platform)[0]
+      expect(sum).to eq(sha256)
+      expect(File.binread(path)).to eq(tarball_content)
+    end
+  end
 end


### PR DESCRIPTION
## What (item 20b)

Per-platform scenario consumption + the msys two-pass build flow, making the windows legs green for real. Builds on tamatebako/ruby **v0.2.1** (77 assets: 19 versions × {linux-gnu unsuffixed, linux-musl, msys-pass1, msys-pass2}).

**Resolution design** (`SourceFetcher.scenario_asset_names`):
- gnu / macos → `tfs-ruby-<v>-src.tar.gz` (unsuffixed linux-gnu scenario, back-compat, proven for both)
- linux-musl → `tfs-ruby-<v>-src-linux-musl.tar.gz` (carries `thread_pthread_main_stack_musl`)
- msys → `tfs-ruby-<v>-src-msys-pass1.tar.gz` **and** `tfs-ruby-<v>-src-msys-pass2.tar.gz` — the consumer never re-derives the pass split; every asset is SHA256-verified against the release SHA256SUMS as today.

**msys two-pass flow** (semantics recovered from the gem's pass1/pass2 classes; the released pass trees differ only in `cygwin/GNUmakefile.in`):
1. The **pass-1** tree drives the main ExternalProject: prepare (@TEBAKO_MLIBS@ + stub driver) → configure → postconfigure → toolchain `make` + `make install` → stash. Its GNUmakefile keeps the implib/exp generation rule (`dlltool --output-lib --output-def=tebako.def --export-all --output-exp`), which the pass-2 variant kills (`dummy.exp`) to reuse pass-1 output.
2. The new **overlay** pass lays the pass-2 tree onto the built pass-1 tree: content-compare per file, fresh mtimes only on replaced files (today exactly one: `cygwin/GNUmakefile.in`), pass-1 build artifacts (objects, `tebako.def`/exp/implib) preserved — the honest equivalent of the gem's "pass2 patches onto the same tree", without touching the patch layer. `prepare` re-runs to re-substitute the `@TEBAKO_MLIBS@` the overlay restored.
3. On msys the stub `libtebako-fs.a` is kept until the finalize relink (removed there), and the deploy pass creates the Windows **import library** (`dlltool -d <name>.def -D <name>.exe --output-lib image/lib/libx64-ucrt-ruby<ver>.a`) into the image — a faithful port of the gem's `create_implib`. `toolchain_stub.c` gains `rb_w32_pread` for ruby < 3.3 msys.
4. Modern driver + libtfs v0.13.0 windows-ucrt64 prebuilt package, as on the POSIX legs.

**Workflow**: musl legs consume the musl scenario automatically (container OSTYPE); windows legs consume the msys passes; **`continue-on-error` for windows is removed** — it was always a scaffold, and this PR's windows legs are the green proof.

## Validation
- Local (macOS arm64): full POSIX 3.3.7 build green after the refactor; stub executes; 40 rspec examples (scenario mapping, two-asset verified fetch, overlay replacement/preservation/hash gate), rubocop clean.
- CI: this PR's windows legs build the msys scenario end-to-end (clock-rename and dirfd issues were linux-gnu-tree artifacts; the msys trees carry all 21 msys patches incl. the modern io shims with the fcntl shim).

## Status update (from CI iteration on this branch)

- The msys two-pass machinery works: windows legs now progress through scenario fetch (both pass trees, SHA256-verified), prepare, configure, and deep into the ruby build.
- Iteration surfaced and fixed one consumer bug: `@TEBAKO_MLIBS@` is POSIX-only; msys delivers MAINLIBS via config.status (prepare skips the template substitution on msys).
- The windows legs are then blocked by **two compile bugs in the v0.2.1 msys io-routing shims (tamatebako/ruby, not this repo)**:
  1. `dir.c: tfs_closedir` returns the **void** `rb_w32_closedir(dirp)` from an `int` function (all lines; `win32/dir.h: void rb_w32_closedir(DIR *);`).
  2. `prism_compile.c` (4.x) uses `O_RDONLY` without `<fcntl.h>` (mingw does not get it transitively).
  Both need an upstream scenario release fix (agent-117). `continue-on-error` for windows therefore **stays** for now, with a comment naming the exact blockers; it flips off when the fixed scenario assets land — the consumer machinery here is already in place.
- Musl legs consume the musl scenario tree (carries `thread_pthread_main_stack_musl`) and are green; all POSIX legs green.
