### PR TITLE
msys arc: real windows gates on tamatebako/ruby v0.2.6 (item 20b)

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -115,14 +115,6 @@ jobs:
     name: Build runtime package for ${{ matrix.env.os }} / ${{ matrix.env.arch }} / Ruby ${{ matrix.ruby }}
     needs: prepare
     runs-on: ${{ matrix.env.host }}
-    # Windows legs are advisory until the msys scenario source compiles on
-    # UCRT64: the v0.2.1 msys trees carry the full msys patch set but two
-    # compile bugs in the io-routing shims (tamatebako/ruby, not this repo):
-    # dir.c tfs_closedir returns the void rb_w32_closedir(), and the 4.x
-    # prism_compile.c shim uses O_RDONLY without <fcntl.h>. The consumer-side
-    # machinery (two-pass overlay flow) is proven up to those errors; the
-    # advisory flips off when a fixed scenario release lands.
-    continue-on-error: ${{ matrix.env.os == 'windows' }}
     strategy:
       fail-fast: false
       matrix:

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -294,12 +294,21 @@ module TebakoRuntimeBuilder
         overlay_src = File.join(work_dir, "overlay-src")
         FileUtils.rm_rf(overlay_src, secure: true)
         FileUtils.mkdir_p(overlay_src)
-        TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["tar", "-xzf", pass2_tarball, "-C", overlay_src])
+        # GNU tar parses 'D:/...' as a remote host on msys; use the /d/...
+        # form there
+        args = ["tar", "-xzf", msys_tar_path(pass2_tarball), "-C", msys_tar_path(overlay_src)]
+        TebakoRuntimeBuilder::BuildHelpers.run_with_capture(args)
         root = Dir.children(overlay_src).map { |child| File.join(overlay_src, child) }
                                         .find { |path| File.directory?(path) }
         raise TebakoRuntimeBuilder::Error.new("overlay tarball carries no source tree", 130) if root.nil?
 
         root
+      end
+
+      def msys_tar_path(path)
+        return path unless TebakoRuntimeBuilder::Platform.new.msys?
+
+        TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["cygpath", "-u", path]).strip
       end
 
       def overlay_differing_files(root, ruby_source_dir)

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -70,7 +70,7 @@ module TebakoRuntimeBuilder
           mlibs = TebakoRuntimeBuilder::Mlibs.new(platform, deps_lib_dir).compute(rv, with_compression: true)
           substitute_tebako_mlibs!(File.join(ruby_source_dir, "template", "Makefile.in"), mlibs)
         end
-        build_toolchain_stub(platform, deps_lib_dir, mount_point, cc)
+        build_toolchain_stub(platform, deps_lib_dir, mount_point, cc, rv)
       end
 
       def postconfigure(ostype, ruby_source_dir, deps_lib_dir, ruby_ver)
@@ -253,13 +253,17 @@ module TebakoRuntimeBuilder
       # <deps_lib_dir>/libtebako-fs.a (the deps lib dir precedes the CMake
       # binary dir in the ruby link flags, so the stub wins the toolchain
       # link; it is removed by the toolchain pass)
-      def build_toolchain_stub(platform, deps_lib_dir, mount_point, cc) # rubocop:disable Metrics/MethodLength
+      def build_toolchain_stub(platform, deps_lib_dir, mount_point, cc, ruby_ver) # rubocop:disable Metrics/MethodLength
         puts "   ... building the toolchain stub libtebako-fs.a"
         FileUtils.mkdir_p(deps_lib_dir)
         obj = File.join(deps_lib_dir, "tebako-toolchain-stub.o")
         lib = File.join(deps_lib_dir, "libtebako-fs.a")
+        defines = ["-DTEBAKO_STUB_MOUNT_POINT=\"#{mount_point}\""]
+        # ruby >= 3.3 defines rb_w32_pread in win32.c; only the older msys
+        # lines need the stub's fallback
+        defines << "-DRB_W32_PRE_33" if platform.msys? && !ruby_ver.ruby33?
         TebakoRuntimeBuilder::BuildHelpers.run_with_capture(
-          [cc, "-c", TOOLCHAIN_STUB_C, "-DTEBAKO_STUB_MOUNT_POINT=\"#{mount_point}\"", "-o", obj]
+          [cc, "-c", TOOLCHAIN_STUB_C, *defines, "-o", obj]
         )
         TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["ar", "rcs", lib, obj])
         if platform.macos?

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -122,6 +122,9 @@ module TebakoRuntimeBuilder
         FileUtils.rm_rf(stash_dir, secure: true)
         FileUtils.mkdir_p(stash_dir)
         FileUtils.cp_r "#{data_src_dir}/.", stash_dir
+        bin = File.join(data_src_dir, "bin")
+        installed = Dir.exist?(bin) ? Dir.children(bin).first(8).join(", ") : "(no bin dir)"
+        puts "   ... toolchain installed: #{installed}"
 
         # The stub driver served the toolchain link; the final relink must
         # resolve -ltebako-fs to the real library in the CMake binary dir.

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -141,8 +141,10 @@ module TebakoRuntimeBuilder
       def overlay(pass2_tarball, pass2_sha256, ruby_source_dir, work_dir)
         puts "-- Running overlay script (msys pass-2 tree)"
 
-        verify_tarball!(pass2_tarball, pass2_sha256)
-        root = extract_overlay(pass2_tarball, work_dir)
+        # RUBY_TARBALL_P2 arrives in ExternalProject URL form (file://...)
+        path = pass2_tarball.sub(%r{\Afile://}, "")
+        verify_tarball!(path, pass2_sha256)
+        root = extract_overlay(path, work_dir)
         puts "   ... overlaid #{overlay_differing_files(root, ruby_source_dir)} pass-2 file(s) onto #{ruby_source_dir}"
       end
 

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -128,8 +128,9 @@ module TebakoRuntimeBuilder
         puts "   ... toolchain installed: #{installed}"
         unless Dir.exist?(bin)
           # make install exited 0 yet installed nothing -- dump the evidence
-          puts "   ... captured 'make install' output (tail):"
-          puts install_out.lines.last(30)
+          puts "   ... #{data_src_dir} top level: #{Dir.children(data_src_dir).join(", ")}"
+          puts "   ... captured 'make install' section headers:"
+          puts install_out.lines.grep(/installing|Installed|skipping|skipped|unknown install|error|cannot/i).first(80)
           puts "   ... rewritten rbconfig prefix lines:"
           puts File.readlines(rbconfig).grep(/CONFIG\["prefix"\]|CONFIG\["RUBY_EXEC_PREFIX"\]|DESTDIR =/)
         end

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -91,6 +91,7 @@ module TebakoRuntimeBuilder
 
         platform = TebakoRuntimeBuilder::Platform.new
         rbconfig = File.join(ruby_source_dir, "rbconfig.rb")
+        install_out = nil
         Dir.chdir(ruby_source_dir) do
           run_make_with_serial_fallback(["make", "-j#{platform.ncores}"])
           # The pre-patched tool/mkconfig.rb bakes the memfs mount point into
@@ -115,7 +116,7 @@ module TebakoRuntimeBuilder
           # ('no such file or directory: ext/extinit.o'). The gem never saw
           # this -- that patch landed only for its final, stable build.
           TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["make", "-j1"])
-          TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["make", "install", "-j1"])
+          install_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["make", "install", "-j1"])
         end
 
         puts "   ... saving pristine Ruby environment to #{stash_dir}"
@@ -125,6 +126,13 @@ module TebakoRuntimeBuilder
         bin = File.join(data_src_dir, "bin")
         installed = Dir.exist?(bin) ? Dir.children(bin).first(8).join(", ") : "(no bin dir)"
         puts "   ... toolchain installed: #{installed}"
+        unless Dir.exist?(bin)
+          # make install exited 0 yet installed nothing -- dump the evidence
+          puts "   ... captured 'make install' output (tail):"
+          puts install_out.lines.last(30)
+          puts "   ... rewritten rbconfig prefix lines:"
+          puts File.readlines(rbconfig).grep(/CONFIG\["prefix"\]|CONFIG\["RUBY_EXEC_PREFIX"\]|DESTDIR =/)
+        end
 
         # The stub driver served the toolchain link; the final relink must
         # resolve -ltebako-fs to the real library in the CMake binary dir.

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -116,7 +116,14 @@ module TebakoRuntimeBuilder
           # ('no such file or directory: ext/extinit.o'). The gem never saw
           # this -- that patch landed only for its final, stable build.
           TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["make", "-j1"])
-          install_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["make", "install", "-j1"])
+          # DESTDIR= override: ruby 4.0's configure.ac seeds DESTDIR=$prefix
+          # when load_relative=yes (forced on msys), and rbinstall's
+          # with_destdir then prepends it to the already-absolute install
+          # dirs, landing the whole tree in a shadow path
+          # (o/s/a/tebako-.../o/s/...). Forcing DESTDIR empty restores the
+          # pass-through; it is a no-op where DESTDIR was already empty
+          # (3.x everywhere, 4.0 POSIX).
+          install_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["make", "install", "-j1", "DESTDIR="])
         end
 
         puts "   ... saving pristine Ruby environment to #{stash_dir}"

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -91,13 +91,22 @@ module TebakoRuntimeBuilder
     # rubygems/gem_runner' -- fail loud with the evidence instead.
     def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
+      begin
+        strings, = Open3.capture2e("strings", ruby)
+        puts "   ... compiled-in paths in #{ruby}:"
+        puts strings.lines.grep(%r{__tebako_memfs__|o/sD:|tebako-runtime-ruby}).first(12)
+      rescue StandardError => e
+        puts "   ... strings failed: #{e.message}"
+      end
+
       probe = <<~RUBY
         puts $LOAD_PATH
-        puts "rbconfig prefix: \#{RbConfig::CONFIG["prefix"]}"
-        puts "rbconfig RUBY_EXEC_PREFIX: \#{RbConfig::CONFIG["RUBY_EXEC_PREFIX"]}"
-        puts "rbconfig rubylibprefix: \#{RbConfig::CONFIG["rubylibprefix"]}"
-        puts "expanded rubylibprefix: \#{RbConfig.expand(RbConfig::CONFIG["rubylibprefix"].to_s)}"
-        puts "rubygems.rb exists in this ruby's view: \#{File.exist?(File.join(#{@data_src_dir.dump}, "lib/ruby/#{@ruby_ver.api_version}/rubygems.rb"))}"
+        begin
+          puts "rbconfig prefix: \#{RbConfig::CONFIG["prefix"] rescue "n/a"}"
+          puts "rbconfig RUBY_EXEC_PREFIX: \#{RbConfig::CONFIG["RUBY_EXEC_PREFIX"] rescue "n/a"}"
+        rescue Exception
+          nil
+        end
         begin
           require "rubygems"
           puts "RUBYGEMS-OK"

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -90,8 +90,16 @@ module TebakoRuntimeBuilder
     # rubygems/gem_runner' -- fail loud with the evidence instead.
     def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
-      probe = 'begin; require "rubygems"; puts "RUBYGEMS-OK"; ' \
-              'rescue Exception => e; puts "#{e.class}: #{e.message}"; puts e.backtrace.first(8); exit 3; end'
+      probe = <<~RUBY
+        begin
+          require "rubygems"
+          puts "RUBYGEMS-OK"
+        rescue Exception => e
+          puts "\#{e.class}: \#{e.message}"
+          puts e.backtrace.first(8)
+          exit 3
+        end
+      RUBY
       load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe])
       if load_path.include?("RUBYGEMS-OK")
         puts "   ... toolchain ruby loads rubygems fine"

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -89,7 +89,7 @@ module TebakoRuntimeBuilder
     # When it is off -- or the recreated environment is incomplete -- every
     # stdlib require fails with a misleading 'cannot load such file --
     # rubygems/gem_runner' -- fail loud with the evidence instead.
-    def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
+    def check_toolchain_ruby! # rubocop:disable Metrics
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       begin
         strings, = Open3.capture2e("strings", ruby)

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -90,22 +90,22 @@ module TebakoRuntimeBuilder
     # rubygems/gem_runner' -- fail loud with the evidence instead.
     def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
-      load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", "puts $LOAD_PATH"])
-      missing = []
-      missing << "$LOAD_PATH lacks #{@data_src_dir}" unless load_path.include?(@data_src_dir)
+      probe = 'begin; require "rubygems"; puts "RUBYGEMS-OK"; ' \
+              'rescue Exception => e; puts "#{e.class}: #{e.message}"; puts e.backtrace.first(8); exit 3; end'
+      load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe])
+      if load_path.include?("RUBYGEMS-OK")
+        puts "   ... toolchain ruby loads rubygems fine"
+        return
+      end
+
       api = @ruby_ver.api_version
       rubygems_rb = File.join(@data_src_dir, "lib", "ruby", api, "rubygems.rb")
-      unless File.file?(rubygems_rb)
-        lib_root = File.join(@data_src_dir, "lib", "ruby", api)
-        listing = Dir.exist?(lib_root) ? Dir.children(lib_root).first(20) : ["<missing #{lib_root}>"]
-        missing << "#{rubygems_rb} is absent; #{lib_root} contains: #{listing.join(", ")}"
-      end
-      return if missing.empty?
-
-      puts "   ... toolchain environment is broken:"
+      present = File.file?(rubygems_rb)
+      listing = Dir.exist?(File.dirname(rubygems_rb)) ? Dir.children(File.dirname(rubygems_rb)).first(20) : []
+      puts "   ... toolchain ruby cannot load rubygems (file present: #{present}):"
       puts load_path
-      missing.each { |item| puts "   ... #{item}" }
-      raise TebakoRuntimeBuilder::Error.new(missing.join("; "), 130)
+      puts "   ... #{File.dirname(rubygems_rb)} contains: #{listing.join(", ")}" if listing.any?
+      raise TebakoRuntimeBuilder::Error.new("toolchain ruby cannot load rubygems from #{@data_src_dir}", 130)
     end
 
     def deploy_env

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -91,17 +91,18 @@ module TebakoRuntimeBuilder
     def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       probe = <<~RUBY
+        puts $LOAD_PATH
+        puts "rubygems.rb exists in this ruby's view: \#{File.exist?(File.join(#{@data_src_dir.dump}, "lib/ruby/#{@ruby_ver.api_version}/rubygems.rb"))}"
         begin
           require "rubygems"
           puts "RUBYGEMS-OK"
         rescue Exception => e
           puts "\#{e.class}: \#{e.message}"
           puts e.backtrace.first(8)
-          exit 3
         end
       RUBY
-      load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe])
-      if load_path.include?("RUBYGEMS-OK")
+      probe_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe])
+      if probe_out.include?("RUBYGEMS-OK")
         puts "   ... toolchain ruby loads rubygems fine"
         return
       end
@@ -110,8 +111,8 @@ module TebakoRuntimeBuilder
       rubygems_rb = File.join(@data_src_dir, "lib", "ruby", api, "rubygems.rb")
       present = File.file?(rubygems_rb)
       listing = Dir.exist?(File.dirname(rubygems_rb)) ? Dir.children(File.dirname(rubygems_rb)).first(20) : []
-      puts "   ... toolchain ruby cannot load rubygems (file present: #{present}):"
-      puts load_path
+      puts "   ... toolchain ruby cannot load rubygems (host sees the file present: #{present}):"
+      puts probe_out
       puts "   ... #{File.dirname(rubygems_rb)} contains: #{listing.join(", ")}" if listing.any?
       raise TebakoRuntimeBuilder::Error.new("toolchain ruby cannot load rubygems from #{@data_src_dir}", 130)
     end

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -84,11 +84,14 @@ module TebakoRuntimeBuilder
     end
 
     # The deploy gem commands run the toolchain ruby from the recreated
-    # environment; its compiled-in prefix must point at it (the toolchain
-    # pass rewrites rbconfig.rb and regenerates verconf.h to achieve that).
-    # When it is off -- or the recreated environment is incomplete -- every
-    # stdlib require fails with a misleading 'cannot load such file --
-    # rubygems/gem_runner' -- fail loud with the evidence instead.
+    # environment. On msys/mingw, configure forces LOAD_RELATIVE, so the
+    # toolchain ruby prepends its exe dir to the compiled-in absolute prefix
+    # and every load-path entry comes out doubled (o/sD:/a/.../o/s/lib/...).
+    # deploy_env therefore carries the real lib dirs in RUBYLIB, which lands
+    # ahead of the compiled entries; this gate probes with that same env so
+    # it validates exactly what the deploy pass gets. When stdlib still does
+    # not resolve, every gem command fails with a misleading 'cannot load
+    # such file -- rubygems/gem_runner' -- fail loud with the evidence instead.
     def check_toolchain_ruby! # rubocop:disable Metrics
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       begin
@@ -115,7 +118,7 @@ module TebakoRuntimeBuilder
           puts e.backtrace.first(8)
         end
       RUBY
-      probe_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe])
+      probe_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe], env: deploy_env)
       if probe_out.include?("RUBYGEMS-OK")
         puts "   ... toolchain ruby loads rubygems fine"
         return
@@ -154,12 +157,29 @@ module TebakoRuntimeBuilder
     end
 
     def deploy_env
-      {
+      env = {
         "GEM_HOME" => @tgd,
         "GEM_PATH" => @tgd,
         "GEM_SPEC_CACHE" => File.join(@data_src_dir, "spec_cache"),
         "TEBAKO_PASS_THROUGH" => "1"
       }
+      env["RUBYLIB"] = toolchain_rubylib if @platform.msys?
+      env
+    end
+
+    # On msys/mingw the toolchain ruby is always LOAD_RELATIVE (configure
+    # forces it) and its compiled-in prefix is absolute, so its load path
+    # comes out doubled: <exe dir>D:/a/.../o/s/lib/... Ship the real lib
+    # dirs via RUBYLIB -- prepended ahead of the compiled entries -- so
+    # rbconfig/rubygems/stdlib resolve. Entries are joined with ";" because
+    # the consumer is a win32 ruby.
+    def toolchain_rubylib # rubocop:disable Metrics
+      lib_ruby = File.join(@data_src_dir, "lib", "ruby")
+      api = @ruby_ver.api_version
+      arch = Dir.children(File.join(lib_ruby, api))
+                .find { |e| File.directory?(File.join(lib_ruby, api, e)) }
+      roots = %w[site_ruby vendor_ruby].map { |b| File.join(lib_ruby, b, api) } << File.join(lib_ruby, api)
+      roots.flat_map { |r| [r, File.join(r, arch)] }.select { |d| File.directory?(d) }.join(";")
     end
 
     def install_gem(name, ver = nil)

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -89,7 +89,7 @@ module TebakoRuntimeBuilder
     # When it is off -- or the recreated environment is incomplete -- every
     # stdlib require fails with a misleading 'cannot load such file --
     # rubygems/gem_runner' -- fail loud with the evidence instead.
-    def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       begin
         strings, = Open3.capture2e("strings", ruby)

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -114,6 +114,16 @@ module TebakoRuntimeBuilder
       puts "   ... toolchain ruby cannot load rubygems (host sees the file present: #{present}):"
       puts probe_out
       puts "   ... #{File.dirname(rubygems_rb)} contains: #{listing.join(", ")}" if listing.any?
+      verconf = File.join(@deps_bin_dir, "..", "src", "_ruby_#{@ruby_ver.ruby_version}", "verconf.h")
+      if File.file?(verconf)
+        puts "   ... verconf.h defines:"
+        puts File.readlines(verconf).grep(/RUBY_EXEC_PREFIX|RUBY_LIB_PREFIX/)
+      end
+      arch_rbconfig = Dir.glob(File.join(@data_src_dir, "lib", "ruby", api, "*", "rbconfig.rb")).first
+      if arch_rbconfig
+        puts "   ... installed rbconfig prefix lines (#{arch_rbconfig}):"
+        puts File.readlines(arch_rbconfig).grep(/CONFIG\["prefix"\]|CONFIG\["RUBY_EXEC_PREFIX"\]|TOPDIR|DESTDIR =/)
+      end
       raise TebakoRuntimeBuilder::Error.new("toolchain ruby cannot load rubygems from #{@data_src_dir}", 130)
     end
 

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -133,6 +133,11 @@ module TebakoRuntimeBuilder
         puts "   ... verconf.h defines:"
         puts File.readlines(verconf).grep(/RUBY_EXEC_PREFIX|RUBY_LIB_PREFIX/)
       end
+      tree_rbconfig = File.join(@deps_bin_dir, "..", "src", "_ruby_#{@ruby_ver.ruby_version}", "rbconfig.rb")
+      if File.file?(tree_rbconfig)
+        puts "   ... build-tree rbconfig prefix lines (#{tree_rbconfig}):"
+        puts File.readlines(tree_rbconfig).grep(/CONFIG\["prefix"\]|CONFIG\["RUBY_EXEC_PREFIX"\]|TOPDIR|DESTDIR =/)
+      end
       arch_rbconfig = Dir.glob(File.join(@data_src_dir, "lib", "ruby", api, "*", "rbconfig.rb")).first
       if arch_rbconfig
         puts "   ... installed rbconfig prefix lines (#{arch_rbconfig}):"

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -39,7 +39,7 @@ module TebakoRuntimeBuilder
   # (DeployHelper#configure: '@needs_bundler = true unless ruby31?',
   # #update_rubygems: 'return if ruby31?') make the rubygems update and the
   # bundler install no-ops, so they are not carried here.
-  class ImageBuilder
+  class ImageBuilder # rubocop:disable Metrics/ClassLength
     def initialize(platform, ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, deps_bin_dir) # rubocop:disable Metrics/ParameterLists
       @platform = platform
       @ruby_ver = ruby_ver

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -102,6 +102,14 @@ module TebakoRuntimeBuilder
         puts "   ... strings failed: #{e.message}"
       end
 
+      # Host-side snapshot of the recreated environment: definitive when the
+      # toolchain ruby is too broken to even run the probe (or is absent).
+      puts "   ... host view of the packaging environment:"
+      [@tbd, File.join(@data_src_dir, "lib", "ruby"),
+       File.join(@data_src_dir, "lib", "ruby", @ruby_ver.api_version)].each do |d|
+        puts "     #{d}: #{Dir.exist?(d) ? Dir.children(d).first(12).join(", ") : "(missing)"}"
+      end
+
       probe = <<~RUBY
         puts $LOAD_PATH
         begin
@@ -118,7 +126,10 @@ module TebakoRuntimeBuilder
           puts e.backtrace.first(8)
         end
       RUBY
-      probe_out = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", probe], env: deploy_env)
+      # --disable-gems: a broken rbconfig otherwise kills the interpreter in
+      # gem_prelude before the probe prints anything. capture2e directly (not
+      # run_with_capture): a failing probe must report, not raise.
+      probe_out, = Open3.capture2e(deploy_env, ruby, "--disable-gems", "-e", probe)
       if probe_out.include?("RUBYGEMS-OK")
         puts "   ... toolchain ruby loads rubygems fine"
         return
@@ -172,14 +183,17 @@ module TebakoRuntimeBuilder
     # comes out doubled: <exe dir>D:/a/.../o/s/lib/... Ship the real lib
     # dirs via RUBYLIB -- prepended ahead of the compiled entries -- so
     # rbconfig/rubygems/stdlib resolve. Entries are joined with ";" because
-    # the consumer is a win32 ruby.
+    # the consumer is a win32 ruby. The arch dir is located through the
+    # installed rbconfig.rb: lib/ruby/<api> also holds plain stdlib dirs
+    # (bigdecimal/, rubygems/, ...), so a directory scan cannot pick it out.
     def toolchain_rubylib # rubocop:disable Metrics
       lib_ruby = File.join(@data_src_dir, "lib", "ruby")
       api = @ruby_ver.api_version
-      arch = Dir.children(File.join(lib_ruby, api))
-                .find { |e| File.directory?(File.join(lib_ruby, api, e)) }
+      rbconfig = Dir.glob(File.join(lib_ruby, api, "*", "rbconfig.rb")).first
+      arch = rbconfig ? File.basename(File.dirname(rbconfig)) : nil
       roots = %w[site_ruby vendor_ruby].map { |b| File.join(lib_ruby, b, api) } << File.join(lib_ruby, api)
-      roots.flat_map { |r| [r, File.join(r, arch)] }.select { |d| File.directory?(d) }.join(";")
+      roots.flat_map { |r| arch ? [r, File.join(r, arch)] : [r] }
+           .select { |d| File.directory?(d) }.join(";")
     end
 
     def install_gem(name, ver = nil)

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -88,7 +88,7 @@ module TebakoRuntimeBuilder
     # When it is off -- or the recreated environment is incomplete -- every
     # stdlib require fails with a misleading 'cannot load such file --
     # rubygems/gem_runner' -- fail loud with the evidence instead.
-    def check_toolchain_ruby!
+    def check_toolchain_ruby! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", "puts $LOAD_PATH"])
       missing = []

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -74,11 +74,30 @@ module TebakoRuntimeBuilder
     def deploy(stub_dir)
       puts "-- Running deploy script"
 
+      check_toolchain_ruby!
       TebakoRuntimeBuilder::BuildHelpers.with_env(deploy_env) do
         install_gem("tebako-runtime")
         deploy_stub(stub_dir)
       end
       TebakoRuntimeBuilder::Stripper.strip(@platform, @data_src_dir)
+    end
+
+    # The deploy gem commands run the toolchain ruby from the recreated
+    # environment; its compiled-in prefix must point at it (the toolchain
+    # pass rewrites rbconfig.rb and regenerates verconf.h to achieve that).
+    # When it is off, every stdlib require fails with a misleading
+    # 'cannot load such file -- rubygems/gem_runner' -- fail loud with the
+    # evidence instead.
+    def check_toolchain_ruby!
+      ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
+      load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", "puts $LOAD_PATH"])
+      return if load_path.include?(@data_src_dir)
+
+      puts "   ... toolchain ruby load path does NOT contain #{@data_src_dir}:"
+      puts load_path
+      raise TebakoRuntimeBuilder::Error.new(
+        "toolchain ruby compiled-in prefix is wrong (expected #{@data_src_dir} in $LOAD_PATH)", 130
+      )
     end
 
     def deploy_env

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -85,19 +85,27 @@ module TebakoRuntimeBuilder
     # The deploy gem commands run the toolchain ruby from the recreated
     # environment; its compiled-in prefix must point at it (the toolchain
     # pass rewrites rbconfig.rb and regenerates verconf.h to achieve that).
-    # When it is off, every stdlib require fails with a misleading
-    # 'cannot load such file -- rubygems/gem_runner' -- fail loud with the
-    # evidence instead.
+    # When it is off -- or the recreated environment is incomplete -- every
+    # stdlib require fails with a misleading 'cannot load such file --
+    # rubygems/gem_runner' -- fail loud with the evidence instead.
     def check_toolchain_ruby!
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       load_path = TebakoRuntimeBuilder::BuildHelpers.run_with_capture([ruby, "-e", "puts $LOAD_PATH"])
-      return if load_path.include?(@data_src_dir)
+      missing = []
+      missing << "$LOAD_PATH lacks #{@data_src_dir}" unless load_path.include?(@data_src_dir)
+      api = @ruby_ver.api_version
+      rubygems_rb = File.join(@data_src_dir, "lib", "ruby", api, "rubygems.rb")
+      unless File.file?(rubygems_rb)
+        lib_root = File.join(@data_src_dir, "lib", "ruby", api)
+        listing = Dir.exist?(lib_root) ? Dir.children(lib_root).first(20) : ["<missing #{lib_root}>"]
+        missing << "#{rubygems_rb} is absent; #{lib_root} contains: #{listing.join(", ")}"
+      end
+      return if missing.empty?
 
-      puts "   ... toolchain ruby load path does NOT contain #{@data_src_dir}:"
+      puts "   ... toolchain environment is broken:"
       puts load_path
-      raise TebakoRuntimeBuilder::Error.new(
-        "toolchain ruby compiled-in prefix is wrong (expected #{@data_src_dir} in $LOAD_PATH)", 130
-      )
+      missing.each { |item| puts "   ... #{item}" }
+      raise TebakoRuntimeBuilder::Error.new(missing.join("; "), 130)
     end
 
     def deploy_env

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -92,6 +92,10 @@ module TebakoRuntimeBuilder
       ruby = File.join(@tbd, "ruby#{@platform.exe_suffix}")
       probe = <<~RUBY
         puts $LOAD_PATH
+        puts "rbconfig prefix: \#{RbConfig::CONFIG["prefix"]}"
+        puts "rbconfig RUBY_EXEC_PREFIX: \#{RbConfig::CONFIG["RUBY_EXEC_PREFIX"]}"
+        puts "rbconfig rubylibprefix: \#{RbConfig::CONFIG["rubylibprefix"]}"
+        puts "expanded rubylibprefix: \#{RbConfig.expand(RbConfig::CONFIG["rubylibprefix"].to_s)}"
         puts "rubygems.rb exists in this ruby's view: \#{File.exist?(File.join(#{@data_src_dir.dump}, "lib/ruby/#{@ruby_ver.api_version}/rubygems.rb"))}"
         begin
           require "rubygems"

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 require "fileutils"
+require "open3"
 
 module TebakoRuntimeBuilder
   # Builds the runtime package filesystem image (fs.bin) from the stashed
@@ -127,6 +128,13 @@ module TebakoRuntimeBuilder
       if arch_rbconfig
         puts "   ... installed rbconfig prefix lines (#{arch_rbconfig}):"
         puts File.readlines(arch_rbconfig).grep(/CONFIG\["prefix"\]|CONFIG\["RUBY_EXEC_PREFIX"\]|TOPDIR|DESTDIR =/)
+      end
+      begin
+        strings, = Open3.capture2e("strings", ruby)
+        puts "   ... compiled-in paths in #{ruby}:"
+        puts strings.lines.grep(%r{/__tebako_memfs__|o/sD:|/lib/ruby}).first(12)
+      rescue StandardError
+        nil
       end
       raise TebakoRuntimeBuilder::Error.new("toolchain ruby cannot load rubygems from #{@data_src_dir}", 130)
     end

--- a/build/lib/tebako_runtime_builder/mlibs.rb
+++ b/build/lib/tebako_runtime_builder/mlibs.rb
@@ -172,7 +172,8 @@ module TebakoRuntimeBuilder
       return lib if name.nil?
 
       vcpkg_lib_dir = Dir.glob(File.join(@deps_lib_dir, "..", "vcpkg_installed", "*", "lib")).min
-      Dir.glob(File.join(vcpkg_lib_dir.to_s, "lib#{name}*.a")).min || lib
+      candidate = Dir.glob(File.join(vcpkg_lib_dir.to_s, "lib#{name}*.a")).min
+      candidate ? File.expand_path(candidate) : lib
     end
 
     def process_brew_libs!(libs, brew_libs)

--- a/build/lib/tebako_runtime_builder/mlibs.rb
+++ b/build/lib/tebako_runtime_builder/mlibs.rb
@@ -103,7 +103,9 @@ module TebakoRuntimeBuilder
       "-static-libgcc",          "-static-libstdc++",       "-l:libssl.a",             "-l:libcrypto.a",
       "-l:libz.a",               "-l:libwinpthread.a",      "-lcrypt32",               "-lshlwapi",
       "-lwsock32",               "-liphlpapi",              "-limagehlp",              "-lbcrypt",
-      "-lole32",                 "-loleaut32",              "-luuid",                  "-lws2_32"
+      "-lwsock32",               "-liphlpapi",              "-limagehlp",              "-lbcrypt",
+      "-lole32",                 "-loleaut32",              "-luuid",                  "-lws2_32",
+      "-lpsapi"
     ].freeze
 
     # The libtfs-deps windows package ships the boost static libs under
@@ -159,7 +161,17 @@ module TebakoRuntimeBuilder
 
     def msys_libraries(ruby_ver, with_compression)
       libraries = with_compression ? ["-Wl,-Bstatic"] : []
-      libraries += COMMON_LINUX_LIBRARIES.map { |lib| msys_boost_reference(lib) } + MSYS_LIBRARIES
+      # The dwarfs reader set + codecs go inside a group: miniruby.exe links
+      # with a bare $(MAINLIBS) rule (no group of its own), and GNU ld's
+      # single-pass scan needs it to resolve the circular member refs
+      # (decompressor_registry -> compression registrar in libdwarfs_common).
+      # COMMON_ARCHIEVE_LIBRARIES adds bz2 (libzip) and the codec set; psapi
+      # covers GetProcessMemoryInfo (libdwarfs_common util.cpp).
+      libraries += ["-Wl,--start-group"] +
+                   COMMON_LINUX_LIBRARIES.map { |lib| msys_boost_reference(lib) } +
+                   COMMON_ARCHIEVE_LIBRARIES +
+                   ["-Wl,--end-group"] +
+                   MSYS_LIBRARIES
       linux_libraries(libraries, ruby_ver, with_compression)
     end
 

--- a/build/lib/tebako_runtime_builder/mlibs.rb
+++ b/build/lib/tebako_runtime_builder/mlibs.rb
@@ -106,6 +106,13 @@ module TebakoRuntimeBuilder
       "-lole32",                 "-loleaut32",              "-luuid",                  "-lws2_32"
     ].freeze
 
+    # The libtfs-deps windows package ships the boost static libs under
+    # toolset/version-tagged names (libboost_filesystem-gcc16-mt-x64-1_90.a),
+    # so the plain -l:libboost_*.a references in COMMON_LINUX_LIBRARIES do
+    # not resolve on msys; they are globbed by full path instead (darwin
+    # style) to stay independent of the tag drift
+    MSYS_BOOST_LIBS = ["boost_filesystem", "boost_chrono"].freeze
+
     # prefix_resolver maps a Homebrew package name to its prefix (darwin);
     # injectable so the list computation is spec-able off macOS
     def initialize(platform, deps_lib_dir, prefix_resolver: nil)
@@ -152,8 +159,20 @@ module TebakoRuntimeBuilder
 
     def msys_libraries(ruby_ver, with_compression)
       libraries = with_compression ? ["-Wl,-Bstatic"] : []
-      libraries += COMMON_LINUX_LIBRARIES + MSYS_LIBRARIES
+      libraries += COMMON_LINUX_LIBRARIES.map { |lib| msys_boost_reference(lib) } + MSYS_LIBRARIES
       linux_libraries(libraries, ruby_ver, with_compression)
+    end
+
+    # Resolve the boost archive references in COMMON_LINUX_LIBRARIES to the
+    # actual (tagged) file in the vcpkg triplet lib dir on msys; anything
+    # else passes through unchanged. An unresolved boost ref falls back to
+    # the plain -l: form so a genuine absence fails loudly at link time.
+    def msys_boost_reference(lib)
+      name = MSYS_BOOST_LIBS.find { |boost| lib == "-l:lib#{boost}.a" }
+      return lib if name.nil?
+
+      vcpkg_lib_dir = Dir.glob(File.join(@deps_lib_dir, "..", "vcpkg_installed", "*", "lib")).min
+      Dir.glob(File.join(vcpkg_lib_dir.to_s, "lib#{name}*.a")).min || lib
     end
 
     def process_brew_libs!(libs, brew_libs)

--- a/build/lib/tebako_runtime_builder/mlibs.rb
+++ b/build/lib/tebako_runtime_builder/mlibs.rb
@@ -111,7 +111,7 @@ module TebakoRuntimeBuilder
     # so the plain -l:libboost_*.a references in COMMON_LINUX_LIBRARIES do
     # not resolve on msys; they are globbed by full path instead (darwin
     # style) to stay independent of the tag drift
-    MSYS_BOOST_LIBS = ["boost_filesystem", "boost_chrono"].freeze
+    MSYS_BOOST_LIBS = %w[boost_filesystem boost_chrono].freeze
 
     # prefix_resolver maps a Homebrew package name to its prefix (darwin);
     # injectable so the list computation is spec-able off macOS

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.2.3"
+    DEFAULT_RELEASE = "v0.2.4"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.2.1"
+    DEFAULT_RELEASE = "v0.2.3"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.2.4"
+    DEFAULT_RELEASE = "v0.2.5"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.2.5"
+    DEFAULT_RELEASE = "v0.2.6"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)

--- a/build/resources/toolchain_stub.c
+++ b/build/resources/toolchain_stub.c
@@ -51,7 +51,9 @@ const char *tebako_original_pwd(void)
 }
 
 /* Referenced by the ruby < 3.3 msys builds (the real driver provides it
-   under RB_W32_PRE_33); harmless elsewhere */
+   under RB_W32_PRE_33); ruby >= 3.3 defines it in win32.c, so it is
+   compiled in only for the older lines */
+#ifdef RB_W32_PRE_33
 ssize_t rb_w32_pread(int fd, void *buf, size_t size, size_t offset)
 {
     (void)fd;
@@ -60,3 +62,4 @@ ssize_t rb_w32_pread(int fd, void *buf, size_t size, size_t offset)
     (void)offset;
     return -1;
 }
+#endif

--- a/spec/mlibs_spec.rb
+++ b/spec/mlibs_spec.rb
@@ -54,13 +54,17 @@ RSpec.describe TebakoRuntimeBuilder::Mlibs do
       described_class.new(TebakoRuntimeBuilder::Platform.new("x64-mingw-ucrt", "x86_64"), "/deps/lib")
     end
 
-    it "prepends -Wl,-Bstatic only with compression" do
-      expect(mlibs.compute(ruby_ver, with_compression: true)).to start_with("-Wl,-Bstatic -Wl,--push-state")
-      expect(mlibs.compute(ruby_ver, with_compression: false)).to start_with("-Wl,--push-state")
+    it "prepends -Wl,-Bstatic only with compression and group-wraps the dwarfs set" do
+      expect(mlibs.compute(ruby_ver,
+                           with_compression: true)).to start_with("-Wl,-Bstatic -Wl,--start-group -Wl,--push-state")
+      expect(mlibs.compute(ruby_ver, with_compression: false)).to start_with("-Wl,--start-group -Wl,--push-state")
+      expect(mlibs.compute(ruby_ver)).to include("-Wl,--end-group")
     end
 
-    it "carries the windows system libs" do
+    it "carries the windows system libs incl. psapi and bz2" do
       expect(mlibs.compute(ruby_ver)).to include("-lws2_32")
+      expect(mlibs.compute(ruby_ver)).to include("-lpsapi")
+      expect(mlibs.compute(ruby_ver)).to include("-l:libbz2.a")
     end
 
     context "with tagged boost archives in the vcpkg triplet" do

--- a/spec/mlibs_spec.rb
+++ b/spec/mlibs_spec.rb
@@ -62,6 +62,35 @@ RSpec.describe TebakoRuntimeBuilder::Mlibs do
     it "carries the windows system libs" do
       expect(mlibs.compute(ruby_ver)).to include("-lws2_32")
     end
+
+    context "with tagged boost archives in the vcpkg triplet" do
+      subject(:mlibs) do
+        described_class.new(TebakoRuntimeBuilder::Platform.new("x64-mingw-ucrt", "x86_64"),
+                            File.join(root, "deps", "lib"))
+      end
+
+      let(:root) { Dir.mktmpdir }
+
+      before do
+        triplet_lib = File.join(root, "deps", "vcpkg_installed", "x64-mingw-static", "lib")
+        FileUtils.mkdir_p(triplet_lib)
+        FileUtils.touch(File.join(triplet_lib, "libboost_filesystem-gcc16-mt-x64-1_90.a"))
+        FileUtils.touch(File.join(triplet_lib, "libboost_chrono-gcc16-mt-x64-1_90.a"))
+      end
+
+      after do
+        FileUtils.remove_entry(root)
+      end
+
+      it "resolves the boost references to the tagged archives by full path" do
+        triplet_lib = File.join(root, "deps", "vcpkg_installed", "x64-mingw-static", "lib")
+        result = mlibs.compute(ruby_ver)
+        expect(result).to include("#{triplet_lib}/libboost_filesystem-gcc16-mt-x64-1_90.a")
+        expect(result).to include("#{triplet_lib}/libboost_chrono-gcc16-mt-x64-1_90.a")
+        expect(result).not_to include("-l:libboost_filesystem.a")
+        expect(result).not_to include("-l:libboost_chrono.a")
+      end
+    end
   end
 
   context "on darwin" do

--- a/spec/mlibs_spec.rb
+++ b/spec/mlibs_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe TebakoRuntimeBuilder::Mlibs do
       let(:root) { Dir.mktmpdir }
 
       before do
+        FileUtils.mkdir_p(File.join(root, "deps", "lib"))
         triplet_lib = File.join(root, "deps", "vcpkg_installed", "x64-mingw-static", "lib")
         FileUtils.mkdir_p(triplet_lib)
         FileUtils.touch(File.join(triplet_lib, "libboost_filesystem-gcc16-mt-x64-1_90.a"))


### PR DESCRIPTION
## What

Final step of the msys arc. `SourceFetcher` pins tamatebako/ruby **v0.2.6** (149 assets, SHA256SUMS-verified), which carries the msys shim audit (tamatebako/ruby#38), WPROGRAM MAINLIBS pass-1 (#39), and the 4.0-line clock-rename drop (#40). `continue-on-error` for windows removed -- windows legs are real gates, building the msys-pass1/pass2 scenario end-to-end (prepare -> configure -> toolchain -> overlay -> deploy+implib -> finalize) through the modern driver + libtfs windows-ucrt64 package.

## Builder fixes the legs proved necessary

- **RUBYLIB for the deploy pass + toolchain gate**: msys toolchains are always LOAD_RELATIVE (configure forces it), so the toolchain ruby prepends its exe dir to the compiled-in absolute prefix and every load-path entry comes out doubled (`o/sD:/a/.../o/s/lib/...`). The deploy pass now carries the real lib dirs in RUBYLIB (lands ahead of the compiled entries; arch dir located through the installed rbconfig.rb, not a directory scan), and a toolchain-ruby gate probes with that same deploy env and fails loud with host-side evidence.
- **`make install` with `DESTDIR=`**: ruby 4.0's configure.ac seeds `DESTDIR=$prefix` when `load_relative=yes` (forced on msys), and rbinstall's `with_destdir` then prepends it to the already-absolute install dirs -- the whole msys 4.0 toolchain landed in a shadow tree (`o/s/a/tebako-.../o/s/...`). The override restores the pass-through and is a no-op where DESTDIR was already empty (3.x everywhere, 4.0 POSIX).

## Validation

- 42 rspec examples, rubocop clean.
- CI run 30180476824: **14/14 legs green**, incl. windows 3.3.7 + 4.0.6 end-to-end (package produced + artifact uploaded).
- The post-merge 19x7 matrix run is the full-matrix publish check (v0.15.9 incl. windows packages).