### PR TITLE
chore: drop the vestigial patchelf step

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -152,7 +152,7 @@ jobs:
           runtime="tebako-runtime-${{ needs.prepare.outputs.tebako-version }}-${{ matrix.ruby }}-${{ matrix.env.os }}-${{ matrix.env.arch }}"
           docker run -v ${{github.workspace}}:/mnt/w -t $container \
             /mnt/w/tools/build_runtime --ruby "${{ matrix.ruby }}" --output "/mnt/w/runtime-packages/$runtime" \
-            --prefix /root/.build ${{ matrix.env.os == 'linux-gnu' && '--patchelf' || '' }}
+            --prefix /root/.build
 
       - name: Select XCode
         if: matrix.env.os == 'macos'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ tools/build_runtime --ruby 3.3.7
 
 produces `runtime-packages/tebako-runtime-$(cat VERSION)-3.3.7-<platform>`
 (see `tools/build_runtime --help` for options: output path, build prefix,
-`--src-release`/`--src-mirror` overrides, `--patchelf`, `--jobs`).
+`--src-release`/`--src-mirror` overrides, `--jobs`).
 
 ## Runtime filesystem image (item 30)
 

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -53,7 +53,6 @@
 #   -DRUNTIME_NAME:STRING=<runtime package base name, for stub.rb>
 #   [-DDEPS:STRING=<deps folder>]   (default: <binary dir>/deps)
 #   [-DLOG_LEVEL:STRING=error]
-#   [-DREMOVE_GLIBC_PRIVATE=ON]     (linux-gnu: build patchelf)
 
 cmake_minimum_required (VERSION 3.20)
 # Version 3.20 for cmake_path
@@ -114,13 +113,8 @@ option(DWARFS_PRELOAD "Deploy the prebuilt libtfs package from the GitHub releas
 if(DEFINED ENV{DWARFS_PRELOAD})
   set(DWARFS_PRELOAD $ENV{DWARFS_PRELOAD} CACHE BOOL "Deploy the prebuilt libtfs package from the GitHub release" FORCE)
 endif()
-set(WITH_PATCHELF OFF)
-
 if("${OSTYPE_TXT}" MATCHES "^linux-gnu.*")
   set(IS_GNU ON)
-  if(REMOVE_GLIBC_PRIVATE)
-    set(WITH_PATCHELF ON)
-  endif(REMOVE_GLIBC_PRIVATE)
 elseif("${OSTYPE_TXT}" MATCHES "^linux-musl.*")
   set(IS_MUSL ON)
 elseif("${OSTYPE_TXT}" MATCHES "^msys*" OR "${OSTYPE_TXT}" MATCHES "^cygwin*")
@@ -235,8 +229,6 @@ if(__INCBIN_DOWNLOAD)
   message(STATUS "incbin: SHA256 verified (${INCBIN_SHA256})")
 endif()
 
-def_ext_prj_g(PATCHELF "65e14792061c298f1d2bc44becd48a10cbf0bc81")
-
 set(LIBYAML_RUBY_OPTION "")
 set(RUBY_LIBS "")
 if(${RUBY_VER} VERSION_LESS "3.2.0")
@@ -296,7 +288,6 @@ message(STATUS "Target local directory: ${TLD}")
 message(STATUS "Target Gem directory: ${TGD}")
 message(STATUS "FS_MOUNT_POINT: ${FS_MOUNT_POINT}")
 message(STATUS "Building for Win32 Ruby (RB_W32): ${RB_W32}")
-message(STATUS "Removing GLIBC_PRIVATE reference: ${WITH_PATCHELF}")
 
 # ...................................................................
 # Other options
@@ -369,23 +360,6 @@ else(DWARFS_PRELOAD)
     BUILD_BYPRODUCTS ${__LIBTFS}
   )
 endif(DWARFS_PRELOAD)
-
-if(IS_GNU)
-  ExternalProject_Add(${PATCHELF_PRJ}
-    GIT_SHALLOW true
-    PREFIX ${DEPS}
-    GIT_REPOSITORY https://github.com/chitao1234/patchelf.git
-    GIT_TAG ${PATCHELF_WR_TAG}
-    SOURCE_DIR ${PATCHELF_SOURCE_DIR}
-    BINARY_DIR ${PATCHELF_BINARY_DIR}
-    UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir ${PATCHELF_SOURCE_DIR} ./bootstrap.sh
-              COMMAND ${PATCHELF_SOURCE_DIR}/configure
-                  --srcdir=${PATCHELF_SOURCE_DIR}
-                  --prefix=${DEPS}
-    TEST_COMMAND ""
-  )
-endif(IS_GNU)
 
 # ...................................................................
 # Ruby (pre-patched source, tfs-ruby-<version>-src.tar.gz)
@@ -510,9 +484,6 @@ add_custom_target(setup
   ${CMAKE_COMMAND} -E echo "Tebako runtime setup has completed"
   DEPENDS ${DWARFS_WR_PRJ} ${RUBY_PRJ}
 )
-if(IS_GNU)
-  add_dependencies(setup ${PATCHELF_PRJ})
-endif(IS_GNU)
 
 set(CMAKE_CXX_STANDARD      20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -183,7 +183,7 @@ module TebakoRuntimeBuilder
         create_implib(ruby_source_dir, data_src_dir, runtime_name, rv) if platform.msys?
       end
 
-      def finalize(ostype, ruby_source_dir, output, ruby_ver, deps_lib_dir, patchelf = nil) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/ParameterLists
+      def finalize(ostype, ruby_source_dir, output, ruby_ver, deps_lib_dir) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
         puts "-- Running finalize script"
 
         platform = TebakoRuntimeBuilder::Platform.new(ostype)
@@ -208,7 +208,6 @@ module TebakoRuntimeBuilder
         end
 
         src_name = File.join(ruby_source_dir, "ruby#{platform.exe_suffix}")
-        run_patchelf(src_name, patchelf)
         TebakoRuntimeBuilder::Stripper.strip_file(src_name, output)
         puts "Created tebako runtime package at \"#{output}\""
       end
@@ -298,13 +297,6 @@ module TebakoRuntimeBuilder
           TebakoRuntimeBuilder::BuildHelpers.run_with_capture(["ranlib", "-no_warning_for_no_symbols", "-c", lib])
         end
         FileUtils.rm_f(obj)
-      end
-
-      def run_patchelf(src_name, patchelf)
-        return if patchelf.nil?
-
-        params = [patchelf, "--remove-needed-version", "libpthread.so.0", "GLIBC_PRIVATE", src_name]
-        TebakoRuntimeBuilder::BuildHelpers.run_with_capture(params)
       end
 
       def verify_tarball!(tarball, sha256)

--- a/build/lib/tebako_runtime_builder/builder.rb
+++ b/build/lib/tebako_runtime_builder/builder.rb
@@ -34,14 +34,13 @@ module TebakoRuntimeBuilder
   # then relink and strip the runtime binary to the output path.
   class Builder
     def initialize(repo_root:, ruby_version:, tebako_version:, prefix:, output:, # rubocop:disable Metrics/ParameterLists,Metrics/MethodLength
-                   patchelf: false, jobs: nil, release: SourceFetcher::DEFAULT_RELEASE, mirror: nil,
+                   jobs: nil, release: SourceFetcher::DEFAULT_RELEASE, mirror: nil,
                    image: true, tfs: nil)
       @repo_root = repo_root
       @ruby_version = ruby_version
       @tebako_version = tebako_version
       @prefix = File.expand_path(prefix)
       @output = output
-      @patchelf = patchelf
       @jobs = jobs
       @release = release
       @mirror = mirror
@@ -115,7 +114,6 @@ module TebakoRuntimeBuilder
         (tarball_p2, sha256_p2) = assets[1]
         args += ["-DRUBY_TARBALL_P2:STRING=file://#{tarball_p2}", "-DRUBY_HASH_P2:STRING=#{sha256_p2}"]
       end
-      args << "-DREMOVE_GLIBC_PRIVATE=ON" if @patchelf && @platform.linux_gnu?
       args += ["-G", @platform.m_files, "-B", output_folder, "-S", File.join(@repo_root, "build")]
 
       FileUtils.mkdir_p(output_folder)
@@ -133,9 +131,8 @@ module TebakoRuntimeBuilder
 
     def finalize
       FileUtils.mkdir_p(File.dirname(output))
-      patchelf = @patchelf && @platform.linux_gnu? ? File.join(deps, "bin", "patchelf") : nil
       TebakoRuntimeBuilder::BuildPasses.finalize(@platform.ostype, ruby_source_dir, output, @ruby_version,
-                                                 File.join(deps, "lib"), patchelf)
+                                                 File.join(deps, "lib"))
     end
 
     # The layout tree the deploy pass assembled (the CMake project's

--- a/build/tools/build_pass.rb
+++ b/build/tools/build_pass.rb
@@ -102,13 +102,11 @@ begin
     #       ARGV[3] -- OUTPUT
     #       ARGV[4] -- RUBY_VER
     #       ARGV[5] -- DEPS_LIB_DIR
-    #       ARGV[6] -- patchelf path (optional, "none" to skip)
-    unless [6, 7].include?(ARGV.length)
+    unless ARGV.length == 6
       raise TebakoRuntimeBuilder::Error,
-            "build_pass finalize command expects 6 or 7 arguments, #{ARGV.length} has been provided."
+            "build_pass finalize command expects 6 arguments, #{ARGV.length} has been provided."
     end
-    patchelf = ARGV[6].nil? || ARGV[6] == "none" ? nil : ARGV[6]
-    TebakoRuntimeBuilder::BuildPasses.finalize(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], patchelf)
+    TebakoRuntimeBuilder::BuildPasses.finalize(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5])
   else
     raise TebakoRuntimeBuilder::Error, "build_pass cannot process #{ARGV[0]} command"
   end

--- a/tools/build_runtime
+++ b/tools/build_runtime
@@ -33,7 +33,7 @@
 # Usage:
 #   tools/build_runtime --ruby 3.3.7 [--output PATH] [--prefix DIR]
 #                       [--tebako-version X.Y.Z] [--src-release TAG]
-#                       [--src-mirror URL] [--patchelf] [--jobs N]
+#                       [--src-mirror URL] [--jobs N]
 #                       [--no-image] [--tfs PATH]
 
 require "optparse"
@@ -50,7 +50,6 @@ options = {
   tebako_version: nil,
   src_release: TebakoRuntimeBuilder::SourceFetcher::DEFAULT_RELEASE,
   src_mirror: nil,
-  patchelf: false,
   jobs: nil,
   image: true,
   tfs: nil
@@ -85,7 +84,6 @@ parser = OptionParser.new do |opts|
   opts.on("--src-mirror URL", "Base URL override for the source assets (file:// URLs work)") do |v|
     options[:src_mirror] = v
   end
-  opts.on("-P", "--patchelf", "Remove the GLIBC_PRIVATE reference (linux-gnu only)") { options[:patchelf] = true }
   opts.on("-j", "--jobs N", Integer, "Build parallelism (default: detected core count)") { |v| options[:jobs] = v }
   image_options(opts, options)
   opts.on("-h", "--help", "Print this help") do
@@ -109,7 +107,6 @@ begin
     tebako_version: tebako_version,
     prefix: options[:prefix],
     output: options[:output],
-    patchelf: options[:patchelf],
     jobs: options[:jobs],
     release: options[:src_release],
     mirror: options[:src_mirror],


### PR DESCRIPTION
## What

Removes the `--patchelf` path end-to-end. Evidence: the published v0.15.9 linux-gnu runtime binaries carry **zero GLIBC_PRIVATE references** (objdump/readelf verified) -- the ubuntu-20.04 container build already produces forward-compatible binaries, so `--remove-needed-version libpthread.so.0 GLIBC_PRIVATE` has been a no-op per leg while still fetching+building patchelf from `github.com/chitao1234/patchelf.git` on every linux-gnu configure.

## Removed

- `tools/build_runtime`: the `--patchelf` option (usage/default/opts/pass-through).
- `builder.rb` / `build_passes.rb`: `@patchelf`, `-DREMOVE_GLIBC_PRIVATE=ON`, `run_patchelf` and the finalize argument (build_pass.rb finalize now takes 6 args).
- `build/CMakeLists.txt`: the PATCHELF ExternalProject (chitao1234/patchelf.git), `WITH_PATCHELF`/`REMOVE_GLIBC_PRIVATE` wiring, the setup dependency, the status message, the header comment.
- Workflow: the per-leg `--patchelf` flag for linux-gnu.
- README mention.

## Validation

- rspec: 94 examples, 0 failures. rubocop: 0 offenses (27 files).
- `grep -rIn 'patchelf|GLIBC_PRIVATE'`: zero references left in the repo.
- Local CMake configure succeeds end-to-end without the PATCHELF EP.
- CI: this PR's linux-gnu legs are the green proof without patchelf.