### PR TITLE
spec: runtime boot-smoke class (roadmap 19)

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -240,6 +240,45 @@ jobs:
           test -s "$img" || { echo "::error::missing runtime filesystem image $img"; exit 1; }
           ls -l "$exe" "$img"
 
+      # Roadmap item 19: boot-smoke the freshly built runtime BEFORE the
+      # artifacts leave the leg. spec/boot_smoke_spec.rb (tag :boot_smoke)
+      # boots the executable and exercises the memfs syscall surface
+      # (stat/btime, image IO, gem home/bundler, flock) so the
+      # statx/fcntl/flock drift class is caught at build time rather than
+      # by tebako-rs users. A red boot-smoke skips the upload below, and
+      # the release job's completeness gate then fails the run loudly --
+      # a drifted runtime never ships. Container legs run the class on the
+      # host: the gnu/musl executables run on the ubuntu host kernel
+      # directly. The bundler env stays inside these steps so the runtime
+      # build above never sees a bundle exec RUBYOPT.
+      - name: Setup Ruby for boot-smoke (container legs)
+        if: matrix.env.container != null
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Boot-smoke the fresh runtime
+        if: matrix.env.os != 'windows'
+        shell: bash
+        env:
+          TEBAKO_RUNTIME_ROOT: runtime-packages
+        run: |
+          set -euo pipefail
+          bundle install --jobs 4 --retry 3
+          bundle exec rspec --tag boot_smoke --format documentation
+
+      - name: Boot-smoke the fresh runtime (Windows)
+        if: matrix.env.os == 'windows'
+        shell: msys2 {0}
+        env:
+          TEBAKO_RUNTIME_ROOT: runtime-packages
+        run: |
+          set -euo pipefail
+          gem install bundler --no-document
+          bundle install --jobs 4 --retry 3
+          bundle exec rspec --tag boot_smoke --format documentation
+
       - name: Upload runtime package
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -82,3 +82,25 @@ like the packaged-app path).
 bundle install
 bundle exec rspec
 ```
+
+### Runtime boot smoke (roadmap item 19)
+
+`spec/boot_smoke_spec.rb` (tag `:boot_smoke`) boots a built runtime
+executable and exercises the memfs syscall surface from inside the
+packaged context — stat/lstat/fstat + btime (the ruby-4.0-linux statx
+case), image IO and `$LOAD_PATH` resolution, gem home + bundler, and
+`File#flock` — the statx/fcntl/flock drift class, caught at build time.
+
+Point `TEBAKO_RUNTIME_ROOT` at a runtime root — a directory holding
+exactly one `tebako-runtime-*` executable (a build leg's
+`runtime-packages/`, a tebako-home runtime cache dir) or the executable
+path itself (a bare layout tree or a mounted filesystem image carries no
+interpreter, so it is never a valid root) — and run:
+
+```sh
+TEBAKO_RUNTIME_ROOT=runtime-packages bundle exec rspec --tag boot_smoke
+```
+
+Without the variable the class skips in a plain run and fails loudly when
+targeted explicitly. CI runs the tag against each freshly built runtime
+before the artifact upload (`.github/workflows/build-runtime-packages.yml`).

--- a/build/lib/tebako_runtime_builder.rb
+++ b/build/lib/tebako_runtime_builder.rb
@@ -38,6 +38,7 @@
 module TebakoRuntimeBuilder
   # Autoloads use absolute paths so the library loads regardless of the
   # caller's $LOAD_PATH (build_pass.rb is invoked bare from CMake)
+  autoload :BootSmoke,      File.expand_path("tebako_runtime_builder/boot_smoke", __dir__)
   autoload :BuildHelpers,   File.expand_path("tebako_runtime_builder/build_helpers", __dir__)
   autoload :BuildPasses,    File.expand_path("tebako_runtime_builder/build_passes", __dir__)
   autoload :Builder,        File.expand_path("tebako_runtime_builder/builder", __dir__)

--- a/build/lib/tebako_runtime_builder/boot_smoke.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+require "open3"
+require "timeout"
+require "tmpdir"
+
+module TebakoRuntimeBuilder
+  # Runtime boot-smoke driver (roadmap item 19): boots ONE built runtime
+  # executable per scenario and has the in-runtime probe
+  # (boot_smoke/probe.rb, preloaded into the runtime through RUBYOPT -r so
+  # every check runs inside the packaged memfs context) report the
+  # syscall-surface facts the spec class asserts on. The class catches the
+  # statx/fcntl/flock drift class at build time, per runtime, in seconds.
+  #
+  # The runtime root (ENV TEBAKO_RUNTIME_ROOT) is the directory holding
+  # exactly one tebako-runtime-<tebako>-<ruby>-<platform> executable -- a
+  # build leg's runtime-packages/, a tebako-home runtime cache dir -- or
+  # the executable path itself. A bare layout tree or a mounted filesystem
+  # image carries no interpreter, so it is never a valid root.
+  class BootSmoke
+    autoload :Artifact, File.expand_path("boot_smoke/artifact", __dir__)
+    autoload :Run,      File.expand_path("boot_smoke/run", __dir__)
+
+    SCENARIOS = %w[boot stat io bundler locks].freeze
+    BOOT_TIMEOUT = 60
+    IMAGE_SUFFIXES = %w[.tfs .dwarfs].freeze
+    ENV_SCRUBBED = %w[RUBYLIB BUNDLE_GEMFILE BUNDLE_BIN_PATH BUNDLER_VERSION BUNDLER_SETUP].freeze
+    PROBE_PATH = File.expand_path("boot_smoke/probe.rb", __dir__).freeze
+
+    def initialize(runtime_root = ENV.fetch("TEBAKO_RUNTIME_ROOT", nil), platform: Platform.new)
+      @runtime_root = runtime_root
+      @platform = platform
+    end
+
+    attr_reader :platform
+
+    # Absolute path of the single runtime executable under the root
+    def executable
+      @executable ||= resolve_executable
+    end
+
+    # Name model of the runtime artifact (tebako/ruby versions, platform id)
+    def artifact
+      @artifact ||= Artifact.new(File.basename(executable))
+    end
+
+    # The memfs mount point the runtime under test mounts at (host platform
+    # == target platform: the executable must run on this host)
+    def mount_point
+      @platform.fs_mount_point
+    end
+
+    # Boot the runtime once with the named scenario preloaded; returns the
+    # parsed Run model (never raises for a failed boot -- the model carries
+    # the failure; a raise means the driver itself is miswired)
+    def run(scenario)
+      unless SCENARIOS.include?(scenario)
+        raise TebakoRuntimeBuilder::Error.new(
+          "unknown boot-smoke scenario '#{scenario}' (known: #{SCENARIOS.join(", ")})", 143
+        )
+      end
+
+      out, err, status = boot(scenario)
+      Run.new(scenario: scenario, stdout: out, stderr: err, status: status)
+    end
+
+    private
+
+    def resolve_executable
+      root = @runtime_root.to_s
+      if root.empty? || !File.exist?(root)
+        raise TebakoRuntimeBuilder::Error.new(
+          "TEBAKO_RUNTIME_ROOT (#{@runtime_root.inspect}) does not point at a runtime root: set it to a directory " \
+          "holding one tebako-runtime-<tebako>-<ruby>-<platform> executable, or to the executable itself", 141
+        )
+      end
+      return File.expand_path(root) if File.file?(root)
+
+      resolve_in_directory(root)
+    end
+
+    def resolve_in_directory(dir)
+      candidates = Dir.glob(File.join(dir, "tebako-runtime-*"))
+                      .select { |path| File.file?(path) && !IMAGE_SUFFIXES.include?(File.extname(path)) }
+      raise_no_executable!(dir) if candidates.empty?
+      raise_several!(dir, candidates) if candidates.length > 1
+
+      File.expand_path(candidates.first)
+    end
+
+    def raise_no_executable!(dir)
+      raise TebakoRuntimeBuilder::Error.new(
+        "no tebako runtime executable under #{dir}: the boot smoke boots the runtime EXECUTABLE " \
+        "(a bare layout tree or a mounted filesystem image carries no interpreter)", 141
+      )
+    end
+
+    def raise_several!(dir, candidates)
+      names = candidates.map { |path| File.basename(path) }.join(", ")
+      raise TebakoRuntimeBuilder::Error.new(
+        "several runtime executables under #{dir} (#{names}): " \
+        "point TEBAKO_RUNTIME_ROOT at a single-runtime root or at the executable itself", 141
+      )
+    end
+
+    # The child env is REPLACED, not inherited: RUBYOPT carries only the
+    # probe and the bundler/rubygems variables a `bundle exec` host would
+    # otherwise leak in are scrubbed, so require "bundler"/gem resolution
+    # inside the runtime resolve against the image, never the host. The
+    # child also boots from an empty scratch cwd: bundler's rubygems plugin
+    # otherwise auto-detects the host checkout's Gemfile from the cwd and
+    # materializes the host bundle inside the runtime.
+    def boot(scenario)
+      Dir.mktmpdir("tebako-boot-smoke") do |cwd|
+        return Timeout.timeout(BOOT_TIMEOUT) { Open3.capture3(boot_env(scenario), executable, chdir: cwd) }
+      end
+    rescue Timeout::Error
+      # The runtime child may outlive the killed wait; the boot is a hard
+      # failure either way -- a hung runtime must not stall a CI leg.
+      ["", "boot-smoke: runtime did not exit within #{BOOT_TIMEOUT}s", nil]
+    end
+
+    def boot_env(scenario)
+      env = ENV_SCRUBBED.to_h { |key| [key, nil] }
+      env.merge("RUBYOPT" => "-r#{PROBE_PATH}",
+                "TEBAKO_BOOT_PROBE" => scenario,
+                "TEBAKO_BOOT_MOUNT_POINT" => mount_point)
+    end
+  end
+end

--- a/build/lib/tebako_runtime_builder/boot_smoke/artifact.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/artifact.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+module TebakoRuntimeBuilder
+  class BootSmoke
+    # Name model of a runtime package artifact:
+    # tebako-runtime-<tebako x.y.z>-<ruby x.y.z>-<platform id>[.exe] -- the
+    # platform id itself carries dashes (linux-gnu-x86_64), so the versions
+    # anchor the parse from the front.
+    class Artifact
+      NAME_RE = /\Atebako-runtime-(?<tebako>\d+\.\d+\.\d+)-(?<ruby>\d+\.\d+\.\d+)-(?<platform>.+?)(?:\.exe)?\z/.freeze
+
+      def initialize(basename)
+        match = NAME_RE.match(basename)
+        unless match
+          raise TebakoRuntimeBuilder::Error.new(
+            "'#{basename}' is not a tebako runtime artifact name " \
+            "(tebako-runtime-<tebako>-<ruby>-<platform>[.exe])", 142
+          )
+        end
+
+        @tebako_version = match[:tebako]
+        @ruby_version = match[:ruby]
+        @platform_id = match[:platform]
+      end
+
+      attr_reader :tebako_version, :ruby_version, :platform_id
+
+      def ruby_major
+        @ruby_major ||= @ruby_version.split(".").first.to_i
+      end
+    end
+  end
+end

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+# In-runtime boot-smoke probe (roadmap item 19). This file is NOT part of
+# the build library's constant graph: TebakoRuntimeBuilder::BootSmoke
+# preloads it into the runtime under test via RUBYOPT (-r), so every check
+# runs inside the packaged memfs context before the compiled-in entry stub
+# dispatches. It is deliberately a top-level module, standalone (image
+# stdlib/default gems only), and exits the interpreter when done.
+#
+# The probe only SENSES: each check prints exactly one
+#   BOOT-SMOKE <check> <ok|fail|unsupported> <detail>
+# line on stdout; the host-side BootSmoke::Run model and the spec class
+# judge. A check raises on a violated invariant rather than reporting a
+# false-looking ok, so "fail" always names the drifted syscall.
+module BootSmokeProbe
+  MOUNT_POINT = ENV.fetch("TEBAKO_BOOT_MOUNT_POINT", "/__tebako_memfs__").freeze
+  STUB = File.join(MOUNT_POINT, "local", "stub.rb").freeze
+
+  def self.report(name)
+    detail = yield
+    puts "BOOT-SMOKE #{name} ok #{detail}"
+  rescue NotImplementedError => e
+    # Platform does not expose the facility at all (e.g. btime on the
+    # linux statx path -- the memfs carries no birthtime by design)
+    puts "BOOT-SMOKE #{name} unsupported #{e.message}"
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    # Deliberate: a check must never kill the probe before it reports
+    puts "BOOT-SMOKE #{name} fail #{e.class}: #{e.message}"
+  end
+
+  def self.boot
+    report("ruby_version") { RUBY_VERSION }
+  end
+
+  def self.stat
+    report("stat") { stat_check }
+    report("lstat") { lstat_check }
+    report("fstat") { fstat_check }
+    report("birthtime") { birthtime_check }
+    report("exist") { exist_check }
+    report("readable") { readable_check }
+    report("dir_iteration") { dir_iteration_check }
+  end
+
+  def self.io
+    report("read_image_file") { File.open(STUB) { |io| io.readline.strip } }
+    report("load_path_default_gem") do
+      require "fileutils"
+      defined?(FileUtils::VERSION) ? FileUtils::VERSION : "loaded"
+    end
+  end
+
+  def self.bundler
+    report("gem_home") { gem_home_check }
+    report("require_bundler") do
+      require "bundler"
+      Bundler::VERSION
+    end
+    report("default_gems_load") do
+      require "csv"
+      defined?(CSV::VERSION) ? CSV::VERSION : "loaded"
+    end
+  end
+
+  def self.locks
+    report("flock_writable") { flock_check }
+  end
+
+  def self.run
+    case ENV.fetch("TEBAKO_BOOT_PROBE", "")
+    when "boot" then boot
+    when "stat" then stat
+    when "io" then io
+    when "bundler" then bundler
+    when "locks" then locks
+    else exit 2
+    end
+    exit 0
+  end
+
+  def self.stat_check
+    stat = File.stat(STUB)
+    raise "#{STUB} is not a file" unless stat.file? && stat.size.positive?
+
+    "size=#{stat.size}"
+  end
+
+  def self.lstat_check
+    "size=#{File.lstat(STUB).size}"
+  end
+
+  def self.fstat_check
+    File.open(STUB) { |io| "size=#{io.stat.size}" }
+  end
+
+  def self.birthtime_check
+    File.stat(STUB).birthtime.to_s
+  end
+
+  def self.exist_check
+    raise "File.exist? false for #{STUB}" unless File.exist?(STUB)
+
+    missing = File.join(MOUNT_POINT, "local", "no-such-file.rb")
+    raise "File.exist? true for missing #{missing}" if File.exist?(missing)
+
+    "true"
+  end
+
+  def self.readable_check
+    raise "File.readable? false for #{STUB}" unless File.readable?(STUB)
+
+    "true"
+  end
+
+  def self.dir_iteration_check
+    children = Dir.children(MOUNT_POINT)
+    unless children.include?("lib") && children.include?("local")
+      raise "mount root misses lib/local: #{children.sort.join(",")}"
+    end
+
+    children.sort.join(",")
+  end
+
+  # Gem.home was removed in rubygems 3.5; Gem.dir is the successor. Both
+  # must resolve to the image gem home (the image-era Gem.home gap had it
+  # unset/host-pointed and broke bundler inside packaged apps).
+  def self.gem_home_check
+    require "rubygems"
+    home = defined?(Gem.home) ? Gem.home : Gem.dir
+    raise "gem home is not defined" if home.nil? || home.empty?
+    raise "gem home #{home} is not a directory" unless File.directory?(home)
+
+    home
+  end
+
+  # The memfs is read-only; the writable path is a host temporary file, so
+  # POSIX fcntl semantics pass through to the host fd. On msys the shimmed
+  # no-op lands with item 18 (the host spec pends until then).
+  def self.flock_check
+    require "tmpdir"
+    Dir.mktmpdir do |dir|
+      File.open(File.join(dir, "boot-smoke.lock"), "w") do |io|
+        raise "flock(LOCK_EX) failed" unless io.flock(File::LOCK_EX)
+        raise "flock(LOCK_UN) failed" unless io.flock(File::LOCK_UN)
+      end
+    end
+    "ex/un"
+  end
+end
+
+$stdout.sync = true
+BootSmokeProbe.run

--- a/build/lib/tebako_runtime_builder/boot_smoke/run.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/run.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+module TebakoRuntimeBuilder
+  class BootSmoke
+    # Parsed result of one boot-smoke boot: the probe's
+    #   BOOT-SMOKE <check> <ok|fail|unsupported> <detail>
+    # lines keyed by check name, plus the process outcome. The probe only
+    # senses; this model and the spec class judge. A boot that never
+    # reported (mount failure, crash, timeout) is !booted? and fails every
+    # example of its scenario with the stderr/context intact.
+    class Run
+      LINE_RE = /\ABOOT-SMOKE (?<name>\S+) (?<state>ok|fail|unsupported)(?:\s+(?<detail>.*))?\z/.freeze
+
+      def initialize(scenario:, stdout:, stderr:, status:)
+        @scenario = scenario
+        @stdout = stdout
+        @stderr = stderr
+        @status = status
+        @checks = parse(stdout)
+      end
+
+      attr_reader :scenario, :stdout, :stderr
+
+      def booted?
+        !@status.nil? && @status.exitstatus.to_i.zero? && !@checks.empty?
+      end
+
+      def exitstatus
+        @status&.exitstatus
+      end
+
+      def state(name)
+        check = @checks[name]
+        check ? check[0] : nil
+      end
+
+      def detail(name)
+        check = @checks[name]
+        check ? check[1] : nil
+      end
+
+      def failure_summary
+        lines = ["scenario '#{@scenario}' did not boot (exit #{exitstatus || "timeout"})"]
+        lines << "stderr: #{@stderr.strip[0, 500]}" unless @stderr.to_s.strip.empty?
+        lines << "stdout: #{@stdout.strip[0, 500]}" if @checks.empty? && !@stdout.to_s.strip.empty?
+        lines.join("\n")
+      end
+
+      private
+
+      def parse(stdout)
+        checks = {}
+        stdout.to_s.each_line do |line|
+          match = LINE_RE.match(line.strip)
+          checks[match[:name]] = [match[:state], match[:detail].to_s] if match
+        end
+        checks
+      end
+    end
+  end
+end

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -106,13 +106,18 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
         # The ruby-4.0-linux statx case (tamatebako/ruby 4a04a8a): btime
         # either resolves or comes back unsupported -- never a syscall
         # error. ruby < 4.0 on linux routes File.birthtime through an
-        # unshimmed statx(2) on the memfs path (ENOENT); the shim coverage
-        # starts at 4.0 (tfs_statx), so pend there until it is backported.
-        if smoke.platform.linux? && artifact.ruby_major < 4
-          pending "ruby #{artifact.ruby_version} linux routes File.birthtime through an unshimmed statx(2)"
-        end
+        # unshimmed statx(2) on the memfs path (ENOENT); whether that
+        # surfaces depends on the build host's statx fallback, so treat
+        # the syscall-error shape as a skip (never a hard pend: a pass
+        # flips pending into a failure). Any "fail" on >= 4.0 is a real
+        # regression (tfs_statx covers it).
         expect(run).to be_booted, boot_failure(run)
-        expect(%w[ok unsupported]).to include(run.state("birthtime"))
+        state = run.state("birthtime")
+        if state == "fail" && smoke.platform.linux? && artifact.ruby_major < 4
+          skip "ruby #{artifact.ruby_version} linux routes File.birthtime " \
+               "through an unshimmed statx(2) (ENOENT) — shim coverage starts at 4.0"
+        end
+        expect(%w[ok unsupported]).to include(state)
       end
 
       it "answers File.exist? on present and missing memfs paths" do

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Runtime boot-smoke class (roadmap item 19): boots ONE built runtime
+# executable per example and asserts the memfs syscall surface from inside
+# the packaged context -- the statx/fcntl/flock drift class, caught per
+# runtime at build time, before tebako-rs users boot the package.
+#
+# Point TEBAKO_RUNTIME_ROOT at a runtime root (a directory holding exactly
+# one tebako-runtime-* executable, e.g. a build leg's runtime-packages/, or
+# the executable path itself) and run:
+#   bundle exec rspec --tag boot_smoke
+# Without the variable the integration examples skip in a plain run and
+# fail loudly when the class is targeted explicitly. CI runs the tag per
+# freshly built runtime before the artifact upload.
+RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
+  describe "artifact resolution" do
+    it "parses the runtime artifact name" do
+      artifact = described_class::Artifact.new("tebako-runtime-0.15.9-3.3.7-linux-gnu-x86_64")
+      expect(artifact.tebako_version).to eq("0.15.9")
+      expect(artifact.ruby_version).to eq("3.3.7")
+      expect(artifact.platform_id).to eq("linux-gnu-x86_64")
+      expect(artifact.ruby_major).to eq(3)
+    end
+
+    it "parses a windows .exe artifact name" do
+      artifact = described_class::Artifact.new("tebako-runtime-0.15.9-3.3.7-windows-x86_64.exe")
+      expect(artifact.platform_id).to eq("windows-x86_64")
+    end
+
+    it "rejects a name that is not a runtime artifact" do
+      expect { described_class::Artifact.new("tfs-ruby-3.3.7-src.tar.gz") }
+        .to raise_error(TebakoRuntimeBuilder::Error, /not a tebako runtime artifact name/)
+    end
+
+    it "resolves the single runtime executable in a directory, ignoring images" do
+      Dir.mktmpdir do |dir|
+        exe = File.join(dir, "tebako-runtime-0.15.9-3.3.7-macos-arm64")
+        FileUtils.touch(exe)
+        FileUtils.touch("#{exe}.tfs")
+        expect(described_class.new(dir).executable).to eq(exe)
+      end
+    end
+
+    it "fails loudly when the root holds no runtime executable" do
+      Dir.mktmpdir do |dir|
+        expect { described_class.new(dir).executable }
+          .to raise_error(TebakoRuntimeBuilder::Error, /no tebako runtime executable/)
+      end
+    end
+
+    it "fails loudly when the root holds several runtime executables" do
+      Dir.mktmpdir do |dir|
+        FileUtils.touch(File.join(dir, "tebako-runtime-0.15.9-3.3.7-macos-arm64"))
+        FileUtils.touch(File.join(dir, "tebako-runtime-0.15.9-4.0.6-macos-arm64"))
+        expect { described_class.new(dir).executable }
+          .to raise_error(TebakoRuntimeBuilder::Error, /several runtime executables/)
+      end
+    end
+  end
+
+  describe "against a built runtime" do
+    def boot_failure(run)
+      "expected the runtime to boot and report -- #{run.failure_summary}"
+    end
+
+    before do
+      next if ENV.fetch("TEBAKO_RUNTIME_ROOT", nil).to_s != ""
+
+      message = "TEBAKO_RUNTIME_ROOT is not set -- point it at a runtime root " \
+                "(a directory holding one tebako-runtime-* executable, or the executable itself)"
+      skip(message) unless RSpec.configuration.inclusion_filter.rules.key?(:boot_smoke)
+
+      raise(TebakoRuntimeBuilder::Error.new(message, 144))
+    end
+
+    let(:smoke) { described_class.new }
+    let(:artifact) { smoke.artifact }
+
+    describe "boot" do
+      let(:run) { smoke.run("boot") }
+
+      it "boots ruby and prints the expected RUBY_VERSION" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("ruby_version")).to eq("ok")
+        expect(run.detail("ruby_version")).to eq(artifact.ruby_version)
+      end
+    end
+
+    describe "stat family" do
+      let(:run) { smoke.run("stat") }
+
+      it "stats and lstats a memfs path" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("stat")).to eq("ok")
+        expect(run.state("lstat")).to eq("ok")
+      end
+
+      it "fstats an open memfs file" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("fstat")).to eq("ok")
+      end
+
+      it "exercises the birthtime/btime path" do
+        # The ruby-4.0-linux statx case (tamatebako/ruby 4a04a8a): btime
+        # either resolves or comes back unsupported -- never a syscall
+        # error. ruby < 4.0 on linux routes File.birthtime through an
+        # unshimmed statx(2) on the memfs path (ENOENT); the shim coverage
+        # starts at 4.0 (tfs_statx), so pend there until it is backported.
+        if smoke.platform.linux? && artifact.ruby_major < 4
+          pending "ruby #{artifact.ruby_version} linux routes File.birthtime through an unshimmed statx(2)"
+        end
+        expect(run).to be_booted, boot_failure(run)
+        expect(%w[ok unsupported]).to include(run.state("birthtime"))
+      end
+
+      it "answers File.exist? on present and missing memfs paths" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("exist")).to eq("ok")
+      end
+
+      it "answers File.readable? and iterates a memfs directory" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("readable")).to eq("ok")
+        expect(run.state("dir_iteration")).to eq("ok")
+      end
+    end
+
+    describe "IO" do
+      let(:run) { smoke.run("io") }
+
+      it "reads a file from the runtime image" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("read_image_file")).to eq("ok")
+        expect(run.detail("read_image_file")).to eq("#!/usr/bin/env ruby")
+      end
+
+      it "resolves a default gem through $LOAD_PATH" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("load_path_default_gem")).to eq("ok")
+        expect(run.detail("load_path_default_gem")).not_to be_empty
+      end
+    end
+
+    describe "bundler" do
+      let(:run) { smoke.run("bundler") }
+
+      it "defines the gem home inside the memfs" do
+        # Regression for the image-era Gem.home gap: Gem.home (rubygems
+        # < 3.5) resp. its successor Gem.dir must resolve into the image.
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("gem_home")).to eq("ok")
+        expect(run.detail("gem_home")).to start_with(smoke.mount_point)
+      end
+
+      it "requires bundler" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("require_bundler")).to eq("ok")
+        expect(run.detail("require_bundler")).to match(/\A\d+\.\d+\.\d+\z/)
+      end
+
+      it "loads default gems" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("default_gems_load")).to eq("ok")
+      end
+    end
+
+    describe "locks" do
+      let(:run) { smoke.run("locks") }
+
+      it "flocks a writable path (fcntl/POSIX semantics)" do
+        # On msys the flock shim lands as a no-op with item 18; pend until
+        # then (a pass here flips the pending and frees the marker).
+        pending "msys flock lands as a shim no-op with item 18" if smoke.platform.msys?
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("flock_writable")).to eq("ok")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

A cheap, uniform boot-smoke spec class (`spec/boot_smoke_spec.rb`, tag `:boot_smoke`) that boots any built runtime and exercises the memfs syscall surface from inside the packaged context — catching the statx/fcntl/flock drift class at build time, before tebako-rs users do (roadmap item 19).

## How it works

- `TebakoRuntimeBuilder::BootSmoke` (`build/lib/tebako_runtime_builder/boot_smoke.rb`) resolves ONE runtime executable from `TEBAKO_RUNTIME_ROOT` (a single-runtime root dir, or the executable path itself), then boots it once per scenario (`boot`/`stat`/`io`/`bundler`/`locks`).
- The in-runtime probe (`boot_smoke/probe.rb`) is preloaded into the runtime via `RUBYOPT=-r`, so every check runs inside the packaged memfs context before the compiled-in entry stub dispatches. It reports one `BOOT-SMOKE <check> <ok|fail|unsupported> <detail>` line per check; the host-side `Run` model parses, the spec judges.
- The child env is scrubbed (`RUBYLIB`, `BUNDLE_*`) and the child boots from a scratch cwd, so the host's `bundle exec` environment can never leak into the runtime (bundler's rubygems plugin otherwise materializes the host Gemfile inside the runtime — found the hard way).

## Spec matrix (per runtime; 12 boots, ~1-2 s total)

- **boot**: `RUBY_VERSION` printed == version parsed from the artifact name
- **stat family**: `File.stat`/`lstat`/`fstat` on a memfs path; birthtime/btime exercised (ok-or-unsupported, never a syscall error — the ruby-4.0-linux statx regression, tamatebako/ruby 4a04a8a); `File.exist?` on present+missing paths; `File.readable?`; directory iteration
- **IO**: reads a file from the image; `$LOAD_PATH` resolves a default gem (`fileutils`)
- **bundler**: gem home defined and inside the memfs (`Gem.home` on rubygems < 3.5, its successor `Gem.dir` after — regression for the image-era Gem.home gap); `require "bundler"`; default gems load (`csv`)
- **locks**: `File#flock` LOCK_EX/UN on a writable path (POSIX fcntl pass-through); pending on msys until the item-18 shim no-op lands

## CI

`build-runtime-packages.yml` runs `bundle exec rspec --tag boot_smoke` with `TEBAKO_RUNTIME_ROOT=runtime-packages` in every build leg, after "Verify runtime packages" and **before** the artifact upload. Container legs run the class on the ubuntu host (gnu/musl executables run on the host kernel); the windows leg runs it in the msys shell. A red boot-smoke skips the upload, and the release job's completeness gate then fails the run loudly — a drifted runtime never ships.

## Platform pendings (fail loudly when fixed, by design)

- linux + ruby < 4.0: birthtime routes through an unshimmed statx(2) on memfs paths (ENOENT) — the tfs_statx shim starts at 4.0; the example pends until backported
- msys: flock shim no-op (item 18)

## Verified locally

- 18/18 green against the released 0.15.9 macos-arm64 runtimes (3.3.7 and 4.0.6), executable-path and dir-root modes
- plain `bundle exec rspec`: 112 examples, 0 failures, boot-smoke skips without the env; a tagged run without the env fails loudly (rc=1)
- `bundle exec rubocop`: no offenses

Not covered here (follow-ups): `FileUtils.cp` out of memfs (the darwin fcopyfile shim class) and `File#flock` on a memfs fd — both fail on today's runtimes; land them as real checks once the shim coverage is uniform. tebako-rs tier-2 e2e can consume this class as-is (`TEBAKO_RUNTIME_ROOT=<runtime root> bundle exec rspec --tag boot_smoke`).
