### PR TITLE
Pin tamatebako/ruby src v0.2.10

### DIFF
--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.2.9"
+    DEFAULT_RELEASE = "v0.2.10"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)


### PR DESCRIPTION
Automated pin bump: tamatebako/ruby published source release **v0.2.10** (release-src completed successfully and dispatched this bump).

- `DEFAULT_RELEASE` in `build/lib/tebako_runtime_builder/source_fetcher.rb`: `v0.2.9` -> `v0.2.10`
- Source release: https://github.com/tamatebako/ruby/releases/tag/v0.2.10

CI runs the full runtime matrix on this pull request. Nothing auto-merges -- a human reviews and merges.