### PR TITLE
Image era: runtime-image driver handoff, no-embed default, factory boot-gap fix (roadmap 11)

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -245,7 +245,9 @@ jobs:
       # boots the executable and exercises the memfs syscall surface
       # (stat/btime, image IO, gem home/bundler, flock) so the
       # statx/fcntl/flock drift class is caught at build time rather than
-      # by tebako-rs users. A red boot-smoke skips the upload below, and
+      # by tebako-rs users. The boot mirrors the image-era bootstrap:
+      # TEBAKO_RUNTIME_IMAGE points at the leg's own .tfs (item 30b). A red
+      # boot-smoke skips the upload below, and
       # the release job's completeness gate then fails the run loudly --
       # a drifted runtime never ships. Container legs run the class on the
       # host: the gnu/musl executables run on the ubuntu host kernel

--- a/README.md
+++ b/README.md
@@ -24,16 +24,34 @@ produces `runtime-packages/tebako-runtime-$(cat VERSION)-3.3.7-<platform>`
 ## Runtime filesystem image (item 30)
 
 Every build also packs the assembled runtime layout tree — the exact tree
-the runtime executable embeds as its memfs image — as a standalone DwarFS
-image next to the executable:
+the v1 runtime executable embedded as its memfs image — as a standalone
+DwarFS image next to the executable:
 
 ```
 runtime-packages/tebako-runtime-$(cat VERSION)-3.3.7-<platform>.tfs
 ```
 
-The image-era lean flow mounts this file directly instead of extracting a
-runtime layout (the runtime executable stays published and consumable as
-before — backward compat). The image is written with the writer defaults
+**Image era (item 30b, the default):** the executable ships WITHOUT the
+embedded incbin image — the standalone `.tfs` is the runtime's only
+filesystem image, and the entry driver mounts the file
+`TEBAKO_RUNTIME_IMAGE` names (an image-era tebako bootstrap sets it after
+resolving the sha256-verified `.tfs` into the shared cache; the v1 handoff
+is unchanged). Standalone use — including `--tebako-extract` — therefore
+takes the variable explicitly:
+
+```sh
+TEBAKO_RUNTIME_IMAGE=$PWD/runtime-packages/tebako-runtime-$(cat VERSION)-3.3.7-<platform>.tfs \
+  runtime-packages/tebako-runtime-$(cat VERSION)-3.3.7-<platform> --tebako-extract layout
+```
+
+Without the variable (and no embedded image) the driver fails startup with
+a message naming the expected handoff; v1 runtimes — the published 0.15.9
+executables, or anything built `--embed-image` — ignore the variable and
+mount the embedded image exactly as before (graceful degradation, no
+republish needed). The variable wins wherever it is set, so an embedded
+build also mounts the named image.
+
+The image is written with the writer defaults
 (mkdwarfs compression level 7) by our own factory toolchain:
 
 1. `tfs mkimage --format dwarfs` (the tebako-rs tfs-cli binary) when one
@@ -46,7 +64,11 @@ before — backward compat). The image is written with the writer defaults
    binds the writer API in-process).
 
 Both are build-time factory tools; neither becomes a runtime dependency of
-the shipped packages. `--no-image` skips the step. Both artifacts are
+the shipped packages. `--no-image` skips the step (only meaningful with
+`--embed-image`, the v1 shape — an image-era executable without the `.tfs`
+cannot boot); `--embed-image` embeds the image into the executable instead
+(v1 backward-compat shape: the variable is honored when set, the embedded
+image otherwise). Both artifacts are
 uploaded to the release; `manifest.json` folds the image into the package's
 entry as an additive `image` key (`filename`/`sha256`/`size_bytes`), and
 `SHA256SUMS.txt` carries both lines.
@@ -88,8 +110,10 @@ bundle exec rspec
 `spec/boot_smoke_spec.rb` (tag `:boot_smoke`) boots a built runtime
 executable and exercises the memfs syscall surface from inside the
 packaged context — stat/lstat/fstat + btime (the ruby-4.0-linux statx
-case), image IO and `$LOAD_PATH` resolution, gem home + bundler, and
-`File#flock` — the statx/fcntl/flock drift class, caught at build time.
+case), image IO and `$LOAD_PATH` resolution, gem home + bundler (incl.
+bundler's process lock degrading to no-lock on the read-only gem home),
+and `File#flock` — the statx/fcntl/flock drift class, caught at build
+time.
 
 Point `TEBAKO_RUNTIME_ROOT` at a runtime root — a directory holding
 exactly one `tebako-runtime-*` executable (a build leg's

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -43,7 +43,11 @@
 #    toolchain ruby link and run as a plain interpreter during
 #    'make install'; it is removed after the toolchain build and the
 #    final relink (tools/build_runtime, after this project builds)
-#    picks up the real libtebako-fs.a with the embedded filesystem
+#    picks up the real libtebako-fs.a
+#  - image era (default, item 30b): the executable carries no embedded
+#    filesystem image (zero-size incbin symbols); the standalone
+#    <runtime>.tfs, mounted via TEBAKO_RUNTIME_IMAGE, is the runtime's
+#    filesystem. -DTEBAKO_EMBED_IMAGE=ON restores the v1 embedded shape.
 #
 # Expected on the cmake command line:
 #   -DTEBAKO_VERSION:STRING=x.y.z   (runtime contract version)
@@ -111,6 +115,12 @@ set(IS_DARWIN OFF)
 set(RB_W32 OFF)
 set(RUBY_WITHOUT_EXT "dbm,win32,win32ole,-test-/*")
 option(DWARFS_PRELOAD "Deploy the prebuilt libtfs package from the GitHub release (OFF builds libtfs from source with the vcpkg toolchain)" ON)
+# Image era (item 30b): the runtime executable ships WITHOUT the embedded
+# incbin filesystem image; the standalone <runtime>.tfs next to it (mounted
+# via TEBAKO_RUNTIME_IMAGE -- see src/tebako-main.cpp) is the runtime's
+# filesystem. ON restores the v1 shape (the image embeds and the variable
+# is ignored unless set) for consumers that resolve the executable alone.
+option(TEBAKO_EMBED_IMAGE "Embed the runtime filesystem image into the executable (v1 shape)" OFF)
 if(DEFINED ENV{DWARFS_PRELOAD})
   set(DWARFS_PRELOAD $ENV{DWARFS_PRELOAD} CACHE BOOL "Deploy the prebuilt libtfs package from the GitHub release" FORCE)
 endif()
@@ -297,6 +307,7 @@ message(STATUS "Target Gem directory: ${TGD}")
 message(STATUS "FS_MOUNT_POINT: ${FS_MOUNT_POINT}")
 message(STATUS "Building for Win32 Ruby (RB_W32): ${RB_W32}")
 message(STATUS "Removing GLIBC_PRIVATE reference: ${WITH_PATCHELF}")
+message(STATUS "Embedding the filesystem image (v1 shape): ${TEBAKO_EMBED_IMAGE}")
 
 # ...................................................................
 # Other options
@@ -317,6 +328,22 @@ if ("-${RUNTIME_NAME}" STREQUAL "-")
 endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/resources/tebako-version.h.in ${GEN_DIR}/tebako-version.h @ONLY)
+
+# The filesystem translation unit: v1 builds embed ${DATA_BIN_FILE} via
+# incbin (the deploy pass writes it with mkdwarfs); image-era builds carry
+# the zero-size symbols instead (gfsSize == 0 -- the driver then mounts the
+# image TEBAKO_RUNTIME_IMAGE names; src/tebako-main.cpp). The zero symbols
+# mirror INCBIN(fs, ...) so the driver links unchanged either way.
+if(TEBAKO_EMBED_IMAGE)
+  set(TEBAKO_FS_IMAGE_DEF "INCBIN(fs, \"${DATA_BIN_FILE}\");")
+else(TEBAKO_EMBED_IMAGE)
+  # extern-and-initializer: definitions with EXTERNAL linkage (a plain
+  # namespace-scope const is internal in C++ and the driver would not link)
+  set(TEBAKO_FS_IMAGE_DEF "/* Image era: no embedded image (item 30b) */\n\
+extern const INCBIN_ALIGN unsigned char gfsData[] = {0};\n\
+extern const unsigned char* const gfsEnd = gfsData;\n\
+extern const unsigned int gfsSize = 0;")
+endif(TEBAKO_EMBED_IMAGE)
 configure_file(${CMAKE_SOURCE_DIR}/resources/tebako-fs.cpp.in ${GEN_DIR}/tebako-fs.cpp @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/resources/stub.rb.in ${GEN_DIR}/local/stub.rb @ONLY)
 
@@ -522,10 +549,15 @@ set(CMAKE_CXX_EXTENSIONS   OFF)
 # Packaged filesystem
 
 add_custom_target(packaged_filesystem
-  COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb deploy ${RUBY_VER} ${RUBY_STASH_DIR} ${DATA_SRC_DIR} ${DATA_PRE_DIR} ${DATA_BIN_FILE} ${GEN_DIR}/local ${DEPS_BIN_DIR} ${RUBY_SOURCE_DIR} ${RUNTIME_NAME}
+  COMMAND ${RUBY_INTERP} ${CMAKE_SOURCE_DIR}/tools/build_pass.rb deploy ${RUBY_VER} ${RUBY_STASH_DIR} ${DATA_SRC_DIR} ${DATA_PRE_DIR} ${DATA_BIN_FILE} ${GEN_DIR}/local ${DEPS_BIN_DIR} ${RUBY_SOURCE_DIR} ${RUNTIME_NAME} $<BOOL:${TEBAKO_EMBED_IMAGE}>
   DEPENDS setup
-  BYPRODUCTS ${DATA_BIN_FILE}
 )
+# The deploy pass writes ${DATA_BIN_FILE} (mkdwarfs) only for the embedded
+# (v1) shape; image-era builds skip it and the incbin TU carries zero-size
+# symbols, so there is no embedded-image dependency to track.
+if(TEBAKO_EMBED_IMAGE)
+  set_property(TARGET packaged_filesystem APPEND PROPERTY BYPRODUCTS ${DATA_BIN_FILE})
+endif(TEBAKO_EMBED_IMAGE)
 
 set(CMAKE_CXX_FLAGS "${RUBY_C_FLAGS} -I${GEN_DIR}")
 
@@ -541,7 +573,11 @@ add_library(tebako-fs STATIC
 # .incbin directive -- a dependency the build system cannot see. Without
 # OBJECT_DEPENDS an incremental rebuild (same build tree, regenerated
 # fs.bin) would relink the runtime against the STALE embedded image.
-set_source_files_properties(${GEN_DIR}/tebako-fs.cpp PROPERTIES OBJECT_DEPENDS ${DATA_BIN_FILE})
+# Image-era builds carry no embedded image: the generated TU holds the
+# zero-size symbols and fs.bin is never written.
+if(TEBAKO_EMBED_IMAGE)
+  set_source_files_properties(${GEN_DIR}/tebako-fs.cpp PROPERTIES OBJECT_DEPENDS ${DATA_BIN_FILE})
+endif(TEBAKO_EMBED_IMAGE)
 
 if(${RUBY_VER} VERSION_LESS "3.3.0" AND ("${OSTYPE_TXT}" MATCHES "^msys*" OR "${OSTYPE_TXT}" MATCHES "^cygwin*"))
   target_compile_definitions(tebako-fs PUBLIC RB_W32_PRE_33)

--- a/build/lib/tebako_runtime_builder/boot_smoke.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke.rb
@@ -135,6 +135,13 @@ module TebakoRuntimeBuilder
     # child also boots from an empty scratch cwd: bundler's rubygems plugin
     # otherwise auto-detects the host checkout's Gemfile from the cwd and
     # materializes the host bundle inside the runtime.
+    #
+    # When the sibling <executable>.tfs exists the handoff mirrors the
+    # image-era bootstrap exactly: TEBAKO_RUNTIME_IMAGE names it and the
+    # driver mounts it (an image-era executable ships no embedded image and
+    # would not boot otherwise; an item-30b embedded executable proves the
+    # variable wins over its incbin image). A runtime root without the
+    # image boots the v1 embedded way, byte-identical to before.
     def boot(scenario)
       Dir.mktmpdir("tebako-boot-smoke") do |cwd|
         return Timeout.timeout(BOOT_TIMEOUT) { Open3.capture3(boot_env(scenario), executable, chdir: cwd) }
@@ -147,6 +154,8 @@ module TebakoRuntimeBuilder
 
     def boot_env(scenario)
       env = ENV_SCRUBBED.to_h { |key| [key, nil] }
+      image = "#{executable}.tfs"
+      env["TEBAKO_RUNTIME_IMAGE"] = image if File.file?(image)
       env.merge("RUBYOPT" => "-r#{PROBE_PATH}",
                 "TEBAKO_BOOT_PROBE" => scenario,
                 "TEBAKO_BOOT_MOUNT_POINT" => mount_point)

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -81,6 +81,7 @@ module BootSmokeProbe
       require "bundler"
       Bundler::VERSION
     end
+    report("process_lock") { process_lock_check }
     report("default_gems_load") do
       require "csv"
       defined?(CSV::VERSION) ? CSV::VERSION : "loaded"
@@ -156,6 +157,21 @@ module BootSmokeProbe
     raise "gem home #{home} is not a directory" unless File.directory?(home)
 
     home
+  end
+
+  # Bundler's ProcessLock targets the bundle path -- Gem.dir, inside the
+  # read-only memfs. Every supported bundler degrades to "no lock" there
+  # (2.5/2.6 rescue EROFS & co., 4.x wraps the failure as PermissionError);
+  # what must never escape is the drift-class errno (the unshimmed
+  # statx/fcopyfile EBADF the image-era boot gap died with -- it matched
+  # none of the rescues and aborted the boot).
+  def self.process_lock_check
+    require "bundler"
+    unless defined?(Bundler::ProcessLock)
+      raise NotImplementedError, "bundler #{Bundler::VERSION} carries no ProcessLock"
+    end
+
+    Bundler::ProcessLock.lock(Gem.dir) { "no-lock-on-memfs" }
   end
 
   # The memfs is read-only; the writable path is a host temporary file, so

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -41,7 +41,8 @@ module TebakoRuntimeBuilder
   #                    config.status (the deferred patch of the canonical set)
   #   toolchain     -- make + make install, stash the pristine ruby
   #                    environment, drop the stub libtebako-fs.a
-  #   deploy        -- assemble the runtime filesystem image (fs.bin)
+  #   deploy        -- assemble the runtime layout tree (and, for the v1
+  #                    embedded shape, the fs.bin image incbin embeds)
   #   finalize      -- relink the ruby program against the real
   #                    libtebako-fs.a and strip it to the output package
   module BuildPasses
@@ -175,11 +176,11 @@ module TebakoRuntimeBuilder
       end
 
       def deploy(ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, stub_dir, deps_bin_dir, # rubocop:disable Metrics/ParameterLists
-                 ruby_source_dir = nil, runtime_name = nil)
+                 ruby_source_dir = nil, runtime_name = nil, embed: true)
         rv = TebakoRuntimeBuilder::RubyVersion.new(ruby_ver)
         platform = TebakoRuntimeBuilder::Platform.new
         TebakoRuntimeBuilder::ImageBuilder.new(platform, rv, stash_dir, data_src_dir, data_pre_dir,
-                                               data_bin_file, deps_bin_dir).build(stub_dir)
+                                               data_bin_file, deps_bin_dir, embed: embed).build(stub_dir)
         create_implib(ruby_source_dir, data_src_dir, runtime_name, rv) if platform.msys?
       end
 

--- a/build/lib/tebako_runtime_builder/builder.rb
+++ b/build/lib/tebako_runtime_builder/builder.rb
@@ -32,10 +32,10 @@ module TebakoRuntimeBuilder
   # fetch the pre-patched ruby source (SHA256-verified against the
   # tamatebako/ruby release SHA256SUMS), run the CMake project in build/,
   # then relink and strip the runtime binary to the output path.
-  class Builder
+  class Builder # rubocop:disable Metrics/ClassLength
     def initialize(repo_root:, ruby_version:, tebako_version:, prefix:, output:, # rubocop:disable Metrics/ParameterLists,Metrics/MethodLength
                    patchelf: false, jobs: nil, release: SourceFetcher::DEFAULT_RELEASE, mirror: nil,
-                   image: true, tfs: nil)
+                   image: true, embed_image: false, tfs: nil)
       @repo_root = repo_root
       @ruby_version = ruby_version
       @tebako_version = tebako_version
@@ -46,11 +46,13 @@ module TebakoRuntimeBuilder
       @release = release
       @mirror = mirror
       @image = image
+      @embed_image = embed_image
       @tfs = tfs
       @platform = TebakoRuntimeBuilder::Platform.new
     end
 
     def run
+      check_image_shape!
       assets = fetcher.fetch_assets(@ruby_version, @platform)
       puts "-- Building tebako runtime for ruby #{@ruby_version} " \
            "(tebako #{@tebako_version}, #{@platform.host_id}, " \
@@ -74,6 +76,17 @@ module TebakoRuntimeBuilder
     end
 
     private
+
+    # A runtime with neither the embedded image (v1 shape) nor the
+    # standalone .tfs (image era) cannot boot at all -- refuse to build it
+    def check_image_shape!
+      return if @image || @embed_image
+
+      raise TebakoRuntimeBuilder::Error.new(
+        "--no-image without --embed-image produces a runtime that carries no filesystem image " \
+        "in any form (it would fail every boot naming TEBAKO_RUNTIME_IMAGE)", 105
+      )
+    end
 
     def fetcher
       @fetcher ||= TebakoRuntimeBuilder::SourceFetcher.new(release: @release, mirror: @mirror,
@@ -116,6 +129,7 @@ module TebakoRuntimeBuilder
         args += ["-DRUBY_TARBALL_P2:STRING=file://#{tarball_p2}", "-DRUBY_HASH_P2:STRING=#{sha256_p2}"]
       end
       args << "-DREMOVE_GLIBC_PRIVATE=ON" if @patchelf && @platform.linux_gnu?
+      args << "-DTEBAKO_EMBED_IMAGE:BOOL=ON" if @embed_image
       args += ["-G", @platform.m_files, "-B", output_folder, "-S", File.join(@repo_root, "build")]
 
       FileUtils.mkdir_p(output_folder)

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -40,8 +40,15 @@ module TebakoRuntimeBuilder
   # (DeployHelper#configure: '@needs_bundler = true unless ruby31?',
   # #update_rubygems: 'return if ruby31?') make the rubygems update and the
   # bundler install no-ops, so they are not carried here.
+  #
+  # The mkdwarfs step (fs.bin, the image incbin embeds) runs only for the
+  # v1 embedded shape (embed: true). Image-era builds (the default, item
+  # 30b) skip it: the executable carries zero-size incbin symbols and the
+  # standalone <runtime>.tfs the ImagePackager writes from the same layout
+  # tree is the runtime's only filesystem image.
   class ImageBuilder # rubocop:disable Metrics/ClassLength
-    def initialize(platform, ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, deps_bin_dir) # rubocop:disable Metrics/ParameterLists
+    def initialize(platform, ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, deps_bin_dir, # rubocop:disable Metrics/ParameterLists,Metrics/MethodLength
+                   embed: true)
       @platform = platform
       @ruby_ver = ruby_ver
       @stash_dir = stash_dir
@@ -49,6 +56,7 @@ module TebakoRuntimeBuilder
       @data_pre_dir = data_pre_dir
       @data_bin_file = data_bin_file
       @deps_bin_dir = deps_bin_dir
+      @embed = embed
 
       @tbd = File.join(@data_src_dir, "bin")
       @tgd = File.join(@data_src_dir, "lib", "ruby", "gems", @ruby_ver.api_version)
@@ -58,7 +66,7 @@ module TebakoRuntimeBuilder
     def build(stub_dir)
       init
       deploy(stub_dir)
-      mkdwarfs
+      mkdwarfs if @embed
     end
 
     private

--- a/build/lib/tebako_runtime_builder/source_fetcher.rb
+++ b/build/lib/tebako_runtime_builder/source_fetcher.rb
@@ -37,7 +37,7 @@ module TebakoRuntimeBuilder
   # SHA256SUMS manifest. Only the asset names and the SHA256SUMS format are
   # part of the contract -- never the repository's internal patch layout.
   class SourceFetcher
-    DEFAULT_RELEASE = "v0.2.9"
+    DEFAULT_RELEASE = "v0.2.10"
     MAX_REDIRECTS = 5
 
     def initialize(cache_dir:, release: DEFAULT_RELEASE, mirror: nil)

--- a/build/resources/tebako-fs.cpp.in
+++ b/build/resources/tebako-fs.cpp.in
@@ -11,6 +11,6 @@ namespace tebako {
   const  char * fs_entry_point = "/local/stub.rb";
   const  char * package_cwd 	 = nullptr;
   char   original_cwd[PATH_MAX];
-
-  INCBIN(fs, "@DATA_BIN_FILE@");
 }
+
+@TEBAKO_FS_IMAGE_DEF@

--- a/build/src/tebako-main.cpp
+++ b/build/src/tebako-main.cpp
@@ -40,6 +40,10 @@
  *    read_self_manifest()
  *  - the launcher ABI v1 handoff (--tebako-image/--tebako-entry/
  *    --tebako-launcher-abi) a tebako-bootstrap execs lean packages with
+ *  - TEBAKO_RUNTIME_IMAGE: in the classic/incbin startup path the named
+ *    runtime filesystem image (.tfs) wins over the embedded incbin image
+ *    (item 30b); image-era builds ship without the embedded image and
+ *    rely on it, v1 runtimes ignore it
  *  - the classic options --tebako-run and --tebako-extract
  *  - the entry dispatch: after mounting, the interpreter is handed
  *    [<argv0>, <mount point><entry point>, <application args...>] and runs
@@ -899,8 +903,34 @@ extern "C" int tebako_main(int* argc, char*** argv)
           }
         }
         else {
-          /* Classic incbin bundle: mount the embedded image from memory */
-          if (tebako_fs_init(&gfsData[0], gfsSize, mount_point.c_str()) != 0) {
+          /* Classic incbin bundle startup: mount the embedded image from
+             memory -- or, when TEBAKO_RUNTIME_IMAGE is set, the runtime's
+             filesystem image it names (item 30b). The variable carries the
+             absolute path of the sha256-verified .tfs artifact the
+             bootstrap resolved into the shared cache; image-era builds ship
+             gfsSize == 0 and rely on it, v1 runtimes ignore it and mount
+             the embedded image exactly as before. */
+          const char* runtime_image = getenv("TEBAKO_RUNTIME_IMAGE");
+          if (runtime_image != nullptr && runtime_image[0] != '\0') {
+            if (tebako_fs_init_from_file(runtime_image, mount_point.c_str()) != 0) {
+              printf("Tebako: failed to mount the runtime filesystem image from '%s': %s\n", runtime_image,
+                     tebako_strerror(tebako_get_errno()));
+              startup_failed = true;
+            }
+            else {
+              mounted = true;
+            }
+          }
+          else if (gfsSize == 0) {
+            /* Image-era build without the variable: nothing embeds the
+               runtime's files anymore, so name the handoff the bootstrap
+               was supposed to perform instead of a bare libtfs error. */
+            printf("Tebako: this runtime carries no embedded filesystem image and TEBAKO_RUNTIME_IMAGE\n"
+                   "  is not set -- resolve the runtime through an image-era tebako bootstrap, or set\n"
+                   "  TEBAKO_RUNTIME_IMAGE to the runtime's .tfs filesystem image.\n");
+            startup_failed = true;
+          }
+          else if (tebako_fs_init(&gfsData[0], gfsSize, mount_point.c_str()) != 0) {
             printf("Tebako: failed to mount the embedded filesystem image: %s\n",
                    tebako_strerror(tebako_get_errno()));
             startup_failed = true;

--- a/build/src/tebako-main.cpp
+++ b/build/src/tebako-main.cpp
@@ -43,7 +43,7 @@
  *  - TEBAKO_RUNTIME_IMAGE: in the classic/incbin startup path the named
  *    runtime filesystem image (.tfs) wins over the embedded incbin image
  *    (item 30b); image-era builds ship without the embedded image and
- *    rely on it, v1 runtimes ignore it
+ *    rely on it, embedded builds mount from memory when it is absent
  *  - the classic options --tebako-run and --tebako-extract
  *  - the entry dispatch: after mounting, the interpreter is handed
  *    [<argv0>, <mount point><entry point>, <application args...>] and runs

--- a/build/tools/build_pass.rb
+++ b/build/tools/build_pass.rb
@@ -80,12 +80,14 @@ begin
     #       ARGV[7] -- DEPS_BIN_DIR
     #       ARGV[8] -- RUBY_SOURCE_DIR (msys implib)
     #       ARGV[9] -- RUNTIME_NAME (msys implib)
-    unless ARGV.length == 10
+    #       ARGV[10] -- EMBED ("1": also write the incbin fs.bin image;
+    #                  "0": image era, the standalone .tfs is the only image)
+    unless ARGV.length == 11
       raise TebakoRuntimeBuilder::Error,
-            "build_pass deploy command expects 10 arguments, #{ARGV.length} has been provided."
+            "build_pass deploy command expects 11 arguments, #{ARGV.length} has been provided."
     end
     TebakoRuntimeBuilder::BuildPasses.deploy(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6], ARGV[7],
-                                             ARGV[8], ARGV[9])
+                                             ARGV[8], ARGV[9], embed: ARGV[10] == "1")
   when "overlay"
     #       ARGV[1] -- PASS2_TARBALL
     #       ARGV[2] -- PASS2_SHA256

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -165,6 +165,14 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
         expect(run.detail("require_bundler")).to match(/\A\d+\.\d+\.\d+\z/)
       end
 
+      it "tolerates bundler's process lock on the read-only memfs" do
+        # The boot gap's second half: ProcessLock targets the read-only
+        # gem home; supported bundlers degrade to no-lock, the drifted
+        # builds escaped with an unrescued EBADF.
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("process_lock")).to eq("ok")
+      end
+
       it "loads default gems" do
         expect(run).to be_booted, boot_failure(run)
         expect(run.state("default_gems_load")).to eq("ok")

--- a/tools/build_runtime
+++ b/tools/build_runtime
@@ -34,7 +34,7 @@
 #   tools/build_runtime --ruby 3.3.7 [--output PATH] [--prefix DIR]
 #                       [--tebako-version X.Y.Z] [--src-release TAG]
 #                       [--src-mirror URL] [--patchelf] [--jobs N]
-#                       [--no-image] [--tfs PATH]
+#                       [--no-image] [--embed-image] [--tfs PATH]
 
 require "optparse"
 
@@ -53,13 +53,17 @@ options = {
   patchelf: false,
   jobs: nil,
   image: true,
+  embed_image: false,
   tfs: nil
 }
 
 # The item-30 image options (kept out of the parser block for readability)
 def image_options(opts, options)
   opts.on("--[no-]image", "Also pack the runtime layout as <output>.tfs next to the executable " \
-                          "(default: on)") { |v| options[:image] = v }
+                          "(default: on; the image era's only filesystem image)") { |v| options[:image] = v }
+  opts.on("--[no-]embed-image", "Embed the filesystem image into the executable (v1 shape; " \
+                                "default: off -- the image-era executable mounts " \
+                                "TEBAKO_RUNTIME_IMAGE instead)") { |v| options[:embed_image] = v }
   opts.on("--tfs PATH", "tfs binary (tebako-rs tfs-cli) for the image step " \
                         "(default: TEBAKO_TFS, then tfs on PATH, then the deps mkdwarfs)") do |v|
     options[:tfs] = v
@@ -114,6 +118,7 @@ begin
     release: options[:src_release],
     mirror: options[:src_mirror],
     image: options[:image],
+    embed_image: options[:embed_image],
     tfs: options[:tfs]
   )
   builder.run


### PR DESCRIPTION
## What

**1. Upstream the image-era driver patch (item 30b).** In the classic/incbin startup path the driver now prefers `TEBAKO_RUNTIME_IMAGE` — the sha256-verified `.tfs` an image-era bootstrap resolved into the shared cache — over the embedded incbin image (`tebako_fs_init_from_file`). With the variable absent, behavior is byte-identical to v1 (embedded mount from memory); an image-era build (`gfsSize == 0`) without the variable fails startup with a message naming the expected handoff instead of a bare libtfs error. Upstream of tebako-rs `docs/tebako-main.cpp.30b.patch`, adapted to this driver's control flow.

**2. Image-era releases as the default published shape.** The runtime executable stops embedding the incbin image: the generated `tebako-fs.cpp` carries zero-size symbols, the deploy pass skips the fs.bin mkdwarfs step, and the standalone `tebako-runtime-<ver>-<ruby>-<platform>.tfs` (packed from the same layout tree — 30a verified: both artifacts upload, the manifest `image` key and both SHA256SUMS lines stay, the release completeness gate requires both) becomes the runtime's only filesystem image. `--embed-image`/`-DTEBAKO_EMBED_IMAGE=ON` restores the v1 embedded shape; `--no-image` without it is rejected (a runtime with no image in any form cannot boot). BootSmoke mirrors the image-era bootstrap: it exports `TEBAKO_RUNTIME_IMAGE` from the sibling `.tfs` when present, so the suite is valid for both shapes and CI legs are unchanged.

**3. The factory-built-image boot gap (tebako-rs README fixture note).** Two stacked causes, both closed:
- Default-gem loading died on the **statx/fcopyfile drift** (reproduced on the stale local runtime: `Errno::EBADF - fcopyfile` in the runtime's own `gem install`) — already fixed by the tamatebako/ruby source pins v0.2.7–v0.2.9 on main.
- **bundler's ProcessLock landed on the read-only memfs**: `tfs_open` in the pre-patched source fell through to the host `open()` for write-flagged opens on in-mount paths, answering ENOENT (the path never exists on the host). POSIX — and the gem's historical behavior (the official 0.15.9 runtime answers EROFS) — is EROFS, and bundler's rescue list only matches the EROFS class. Fixed upstream in tamatebako/ruby **v0.2.10** (PR tamatebako/ruby#42, merged; release published; pin bumped here). The boot-smoke bundler group gains a `process_lock` probe asserting the contract: `Bundler::ProcessLock.lock(Gem.dir)` degrades to no-lock on the read-only memfs.

## Verification (local)

- macOS arm64 3.3.7 leg: lean executable (24.4 → 19.2 MB) boots via the env image; bare boot without env fails naming `TEBAKO_RUNTIME_IMAGE`; `--tebako-extract` works via the env image; boot-smoke 19/19 green incl. the bundler group. The `--embed-image` escape hatch builds the 24.4 MB v1 shape that boots bare.
- Official-vs-factory probe: write-open on the memfs → EROFS on both (was ENOENT on factory).
- Image-era e2e against a factory pair (tebako-rs M8 CLI): press seeds from the `.tfs` in-process (no `--tebako-extract`, no cache `layout/`), cold run resolves exe + image (sha256 markers, read-only 0444), `TEBAKO_RUNTIME_IMAGE` handoff — gemfile app prints `Hello from gemfile app with rake 13.4.2`.
- linux-gnu x86_64 3.3.7 leg built in docker from a v0.2.10-equivalent local source mirror: boot-smoke + extract evidence below / in CI.

## What CI must still prove

- Full matrix legs (incl. musl + windows advisory) build the no-embed shape and boot-smoke green against the leg's own `.tfs`, with the release completeness gate over both artifacts.
- The ruby 4.0.6 legs: bundler 4.0.16's ProcessLock path (`Gem.open_file_with_lock` + `filesystem_access`) degrades on EROFS the same way.