### PR TITLE
Bootstrap↔runtime contract version 1 (roadmap 45, runtime-image side)

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -102,6 +102,14 @@ jobs:
           echo "Building runtimes for Tebako version $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # Roadmap 45: fail before the matrix builds anything if contract.yml
+      # (the release pipeline's source of truth) and the compiled-in
+      # TEBAKO_CONTRACT_VERSION in the runtime driver disagree -- a contract
+      # bump edits both in the same commit.
+      - name: Check contract version agreement
+        run: |
+          ./scripts/check_contract_version.rb
+
       - name: Generate build matrix
         id: set-matrix
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "base64", "~> 0.2.0"
 gem "faraday-retry", "~> 2.2"
 gem "json", "~> 2.6"
+gem "json_schemer", "~> 2.4"
 gem "octokit", "~> 7.1"
 gem "thor", "~> 1.3"
 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,44 @@ the ruby executable and the bin shims are stripped from the layout; the
 interpreter is the outer driver executable that mounts the image, exactly
 like the packaged-app path).
 
+## Bootstrap ↔ runtime contract version (roadmap 45)
+
+The bootstrap (released from tamatebako/tebako) and the runtime images
+published here version independently, so the protocol between them — the
+env vars passed down, the argv layout, the filesystem-image handoff — is
+versioned as an integer **contract**. Contract 1 pins today's semantics
+exactly; current behavior IS the contract.
+
+Two representations, locked in agreement by CI
+(`scripts/check_contract_version.rb`, run in the prepare job before the
+matrix builds, and by `spec/contract_spec.rb`):
+
+- `contract.yml` (schema: `schema/contract.schema.yml`) — the release
+  pipeline's single source of truth. `scripts/upload_release.rb` emits it
+  as an additive `contract_version` key in every `manifest.json` package
+  entry (consumers ignoring the key keep working, same rule as `image`).
+- `TEBAKO_CONTRACT_VERSION` in `build/src/tebako-main.cpp` — the constant
+  compiled into the runtime itself. The driver exports it as the
+  `TEBAKO_CONTRACT_VERSION` environment variable before the entry dispatch,
+  so the packaged context (and any driver-stage tooling) can read the
+  contract the runtime speaks.
+
+**Bump rules:** any change to env/argv/handoff semantics bumps the integer
+by exactly +1 in BOTH places, same commit — the agreement check fails the
+build otherwise. The bootstrap side (negotiation, `min_contract..max_contract`
+range, `ContractMismatch` named error) lives in the tebako-rs workspace; the
+version → semantics changelog table is spec 06's.
+
 ## Layout
 
-- `VERSION` — the runtime contract version: package names and the release
-  tag follow it (`v$(cat VERSION)`), and the gem's RuntimeManager resolves
-  packages by exactly this version. Bump it in lockstep with the tebako gem
-  version the produced runtimes serve.
+- `VERSION` — the package version: package names and the release tag follow
+  it (`v$(cat VERSION)`), and the gem's RuntimeManager resolves packages by
+  exactly this version. Bump it in lockstep with the tebako gem version the
+  produced runtimes serve. (Not the roadmap-45 contract version — that one
+  lives in `contract.yml`.)
+- `contract.yml` + `schema/` — the bootstrap ↔ runtime contract version
+  (roadmap 45) and its JSON schema; `scripts/check_contract_version.rb`
+  locks it against the compiled-in constant (see the contract section above).
 - `build/` — the self-contained CMake build project (vendored from the
   tebako gem's runtime press driver, adapted to the pre-patched source):
   `CMakeLists.txt`, `cmake/`, `cmake-scripts/`, `src/tebako-main.cpp`,

--- a/build/src/tebako-main.cpp
+++ b/build/src/tebako-main.cpp
@@ -116,6 +116,22 @@
 #define TEBAKO_LAUNCHER_ENTRY_ARG "--tebako-entry"
 #define TEBAKO_LAUNCHER_VERSION_ARG "--tebako-launcher-abi"
 
+/*
+ * Bootstrap <-> runtime contract version (roadmap 45): the env vars passed
+ * down, the argv layout, and the filesystem-image handoff this runtime
+ * speaks. Contract 1 pins the current semantics exactly. The release
+ * pipeline's single source of truth is contract.yml at the repo root --
+ * manifest.json emits the field from it -- and this compiled-in constant is
+ * the runtime's own knowledge of the contract; the two are CI-locked in
+ * agreement by scripts/check_contract_version.rb. The driver exports the
+ * value as the TEBAKO_CONTRACT_VERSION environment variable before the
+ * entry dispatch (below). Bump rules: any change to env/argv/handoff
+ * semantics = +1 in both places, same commit.
+ */
+#define TEBAKO_CONTRACT_VERSION 1
+#define TEBAKO_STRINGIZE_DETAIL(x) #x
+#define TEBAKO_STRINGIZE(x) TEBAKO_STRINGIZE_DETAIL(x)
+
 static int running_miniruby = 0;
 /* Owns the dispatch argv handed to the interpreter; process-lifetime like
    the incbin section itself (ruby reads argv until process exit). */
@@ -757,6 +773,18 @@ extern "C" int tebako_main(int* argc, char*** argv)
     running_miniruby = -1;
   }
   else {
+    /*
+     * Roadmap 45: export this runtime's contract version before anything
+     * else runs. The runtime is authoritative for the contract it speaks,
+     * so an inherited value is always overwritten. The miniruby pass-through
+     * above is a build-time tool and exports nothing.
+     */
+#ifdef _WIN32
+    _putenv_s("TEBAKO_CONTRACT_VERSION", TEBAKO_STRINGIZE(TEBAKO_CONTRACT_VERSION));
+#else
+    setenv("TEBAKO_CONTRACT_VERSION", TEBAKO_STRINGIZE(TEBAKO_CONTRACT_VERSION), 1);
+#endif
+
     std::string mount_point = tebako::fs_mount_point;
     std::string entry_point = tebako::fs_entry_point;
     std::optional<std::string> cwd;

--- a/contract.yml
+++ b/contract.yml
@@ -1,0 +1,16 @@
+# Bootstrap <-> runtime contract version (roadmap 45): the versioned
+# protocol between the tebako bootstrap (released from tamatebako/tebako)
+# and the runtime images published from this repo -- the env vars passed
+# down, the argv layout, and the filesystem-image handoff. Contract 1 pins
+# today's semantics exactly; the current semantics ARE the contract.
+#
+# Bump rules: any change to env/argv/handoff semantics bumps the integer
+# by exactly +1, here and in the compiled-in TEBAKO_CONTRACT_VERSION in
+# build/src/tebako-main.cpp (the two are CI-locked in agreement by
+# scripts/check_contract_version.rb). The release pipeline reads this file
+# (scripts/upload_release.rb emits it into every manifest.json entry) and
+# the driver exports it as the TEBAKO_CONTRACT_VERSION env var.
+#
+# Schema: schema/contract.schema.yml (validated by the same check).
+---
+contract_version: 1

--- a/schema/contract.schema.yml
+++ b/schema/contract.schema.yml
@@ -1,0 +1,11 @@
+# JSON Schema (draft 2020-12) for contract.yml -- the bootstrap <-> runtime
+# contract version manifest (roadmap 45).
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: tebako-runtime-ruby bootstrap <-> runtime contract
+type: object
+required: [contract_version]
+additionalProperties: false
+properties:
+  contract_version:
+    type: integer
+    minimum: 1

--- a/scripts/check_contract_version.rb
+++ b/scripts/check_contract_version.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of tamatebako
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require "bundler/setup"
+require "json_schemer"
+require "pathname"
+require "yaml"
+
+# Contract version agreement check (roadmap 45). The bootstrap <-> runtime
+# contract version lives in TWO representations on purpose:
+#   - contract.yml at the repo root -- the release pipeline's source of
+#     truth (scripts/upload_release.rb emits it into every manifest.json
+#     entry, schema/contract.schema.yml governs the file)
+#   - TEBAKO_CONTRACT_VERSION in build/src/tebako-main.cpp -- the constant
+#     compiled into the runtime and exported as the env var of the same name
+# The two must never drift: a contract bump edits both in the same commit,
+# and this check fails the build-runtime-packages workflow (and the spec
+# suite) when they disagree.
+class ContractVersionCheck
+  REPO_ROOT = Pathname.new(File.expand_path("..", __dir__)).freeze
+  CONTRACT_YML = REPO_ROOT.join("contract.yml").freeze
+  SCHEMA_YML = REPO_ROOT.join("schema", "contract.schema.yml").freeze
+  DRIVER_SRC = REPO_ROOT.join("build", "src", "tebako-main.cpp").freeze
+
+  DEFINE_PATTERN = /^\s*#\s*define\s+TEBAKO_CONTRACT_VERSION\s+(\d+)u?\s*$/.freeze
+
+  def initialize(contract_yml: CONTRACT_YML, schema_yml: SCHEMA_YML, driver_src: DRIVER_SRC)
+    @contract_yml = Pathname.new(contract_yml)
+    @schema_yml = Pathname.new(schema_yml)
+    @driver_src = Pathname.new(driver_src)
+  end
+
+  # Human-readable violations: schema errors against contract.yml, a missing
+  # compiled-in constant, or a yaml/driver disagreement. Empty when the
+  # contract is well-formed and both representations agree.
+  def errors
+    violations = schema_errors
+    if violations.empty? && driver_version.nil?
+      violations << "#{@driver_src} carries no #define TEBAKO_CONTRACT_VERSION -- " \
+                    "the runtime must compile its contract version in (roadmap 45)"
+    elsif violations.empty? && driver_version != yaml_version
+      violations << "contract.yml contract_version is #{yaml_version} but the compiled-in " \
+                    "TEBAKO_CONTRACT_VERSION in #{@driver_src} is #{driver_version} -- " \
+                    "a contract bump edits both in the same commit (roadmap 45)"
+    end
+    violations
+  end
+
+  def valid?
+    errors.empty?
+  end
+
+  def yaml_version
+    data = YAML.load_file(@contract_yml)
+    data.is_a?(Hash) ? data["contract_version"] : nil
+  end
+
+  def driver_version
+    match = @driver_src.each_line.find { |line| line.match?(DEFINE_PATTERN) }&.match(DEFINE_PATTERN)
+    match && match[1].to_i
+  end
+
+  private
+
+  def schema_errors
+    schemer = JSONSchemer.schema(YAML.load_file(@schema_yml))
+    schemer.validate(YAML.load_file(@contract_yml)).map do |problem|
+      "#{@contract_yml}: #{problem.fetch("error", problem.to_s)}"
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  begin
+    check = ContractVersionCheck.new
+    if check.valid?
+      puts "contract version #{check.yaml_version}: contract.yml and the compiled-in TEBAKO_CONTRACT_VERSION agree"
+    else
+      check.errors.each { |error| puts "::error::#{error}" }
+      exit 1
+    end
+  rescue StandardError => e
+    puts "::error::contract version check failed: #{e.message}"
+    exit 1
+  end
+end

--- a/scripts/upload_release.rb
+++ b/scripts/upload_release.rb
@@ -31,8 +31,15 @@ require "octokit"
 require "digest"
 require "json"
 require "pathname"
+require "yaml"
 
 RUNTIME_REPO = "tamatebako/tebako-runtime-ruby"
+
+# The bootstrap <-> runtime contract version (roadmap 45) emitted into every
+# manifest entry. contract.yml at the repo root is the release pipeline's
+# single source of truth; the compiled-in TEBAKO_CONTRACT_VERSION in the
+# runtime driver is CI-locked to agree with it (scripts/check_contract_version.rb).
+CONTRACT_YML = Pathname.new(File.expand_path("../contract.yml", __dir__)).freeze
 
 # Upload release manager for tebako build workflow
 class ReleaseManager # rubocop:disable Metrics/ClassLength
@@ -42,6 +49,17 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
     @version = ENV.fetch("TEBAKO_VERSION")
     @tag = "v#{@version}"
     @release_title = "Tebako runtime packages #{@tag}"
+    @contract_version = load_contract_version
+  end
+
+  # Fail closed: a release whose manifest cannot name the runtime contract
+  # version never ships (the bootstrap negotiates on this field).
+  def load_contract_version
+    data = YAML.load_file(CONTRACT_YML)
+    version = data.is_a?(Hash) ? data["contract_version"] : nil
+    return version if version.is_a?(Integer) && version.positive?
+
+    raise "#{CONTRACT_YML} does not define a positive integer contract_version (roadmap 45)"
   end
 
   # One manifest entry per runtime PACKAGE (the executable). A sibling
@@ -49,7 +67,8 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
   # package's entry as an additive `image` key -- top-level entries stay
   # one-per-package so existing consumers (which match on ruby_version /
   # platform / filename) are unaffected, and a .tfs file never becomes
-  # a top-level entry of its own.
+  # a top-level entry of its own. The additive `contract_version` key
+  # (roadmap 45) follows the same compat rule.
   def build_manifest_entries(packages)
     executables, images = packages.partition { |package| !image_file?(package) }
     executables.sort_by { |package| package.basename.to_s }.map do |package|
@@ -167,6 +186,7 @@ class ReleaseManager # rubocop:disable Metrics/ClassLength
     ruby_version, platform = parse_package_filename(package.basename.to_s)
     {
       tebako_version: @version,
+      contract_version: @contract_version,
       ruby_version: ruby_version,
       platform: platform,
       filename: package.basename.to_s,

--- a/spec/contract_spec.rb
+++ b/spec/contract_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pathname"
+
+require_relative "../scripts/check_contract_version"
+
+# Roadmap 45: the release pipeline's contract.yml and the runtime driver's
+# compiled-in TEBAKO_CONTRACT_VERSION are two representations of one
+# contract; this class is the drift guard CI runs before the matrix builds.
+RSpec.describe ContractVersionCheck do
+  def with_fixtures(contract_body, driver_body)
+    Dir.mktmpdir do |dir|
+      root = Pathname.new(dir)
+      contract = root.join("contract.yml")
+      contract.write(contract_body)
+      driver = root.join("tebako-main.cpp")
+      driver.write(driver_body)
+      yield described_class.new(contract_yml: contract, driver_src: driver)
+    end
+  end
+
+  it "the repo contract.yml validates against the schema and agrees with the driver" do
+    expect(described_class.new.errors).to be_empty
+  end
+
+  it "reads both representations (bump-proof: never hardcode the value here)" do
+    check = described_class.new
+    expect(check.yaml_version).to be_a(Integer)
+    expect(check.driver_version).to eq(check.yaml_version)
+  end
+
+  it "passes when the fixtures agree" do
+    with_fixtures("contract_version: 2\n", "#define TEBAKO_CONTRACT_VERSION 2\n") do |check|
+      expect(check.errors).to be_empty
+    end
+  end
+
+  it "fails when the yaml and the compiled-in constant disagree, naming both" do
+    with_fixtures("contract_version: 2\n", "#define TEBAKO_CONTRACT_VERSION 1\n") do |check|
+      expect(check.errors).to contain_exactly(a_string_matching(/contract_version is 2.*TEBAKO_CONTRACT_VERSION.*is 1/))
+    end
+  end
+
+  it "fails when the driver carries no compiled-in constant" do
+    with_fixtures("contract_version: 1\n", "#define TEBAKO_LAUNCHER_ABI_VERSION 1u\n") do |check|
+      expect(check.errors).to contain_exactly(a_string_matching(/carries no #define TEBAKO_CONTRACT_VERSION/))
+    end
+  end
+
+  it "fails when contract.yml violates the schema" do
+    with_fixtures("contract_version: one\n", "#define TEBAKO_CONTRACT_VERSION 1\n") do |check|
+      expect(check.errors.size).to eq(1)
+      expect(check.errors.first).to include("contract.yml")
+    end
+  end
+
+  it "fails when contract.yml carries unknown keys" do
+    with_fixtures("contract_version: 1\nother: 2\n", "#define TEBAKO_CONTRACT_VERSION 1\n") do |check|
+      expect(check.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/release_manager_spec.rb
+++ b/spec/release_manager_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "digest"
 require "json"
 require "pathname"
+require "yaml"
 
 require_relative "../scripts/upload_release"
 
@@ -161,11 +162,25 @@ RSpec.describe ReleaseManager do
 
     entry = manager.build_manifest_entries([exe, img]).first
 
-    expect(entry.keys).to contain_exactly(:tebako_version, :ruby_version, :platform,
+    expect(entry.keys).to contain_exactly(:tebako_version, :contract_version, :ruby_version, :platform,
                                           :filename, :sha256, :size_bytes, :image)
     expect(entry[:tebako_version]).to eq(SPEC_VERSION)
     expect(entry[:sha256]).to eq(Digest::SHA256.file(exe).hexdigest)
     expect(entry[:size_bytes]).to eq(exe.size)
+  end
+
+  # Roadmap 45: every published package entry names the bootstrap <->
+  # runtime contract it was built for; the value comes from contract.yml,
+  # the release pipeline's single source of truth (never hardcode it here --
+  # the next contract bump edits contract.yml and the driver define only).
+  it "emits the repo contract version into every manifest entry" do
+    expected = YAML.load_file(File.join(REPO_ROOT, "contract.yml")).fetch("contract_version")
+    exe = package("tebako-runtime-#{SPEC_VERSION}-3.3.7-macos-arm64")
+    other = package("tebako-runtime-#{SPEC_VERSION}-3.1.6-linux-gnu-x86_64")
+
+    entries = manager.build_manifest_entries([exe, other])
+
+    expect(entries.map { |entry| entry[:contract_version] }).to eq([expected, expected])
   end
 
   it "checksummes both the package and its image, image line following its package" do


### PR DESCRIPTION
## What

Roadmap 45 (P0) versions the protocol between the independently-released bootstrap (tamatebako/tebako) and these runtime images: the env vars passed down, the argv layout, and the filesystem-image handoff. **Contract 1 pins today's semantics exactly — no runtime behavior change.** This PR is the runtime-image half; the bootstrap negotiation side (supported range, `ContractMismatch` named error, spec 06 contract table) is queued in the tebako-rs workspace.

## How it works

- **Single source of truth:** `contract.yml` (`contract_version: 1`) with `schema/contract.schema.yml` — the versioned-YAML + JSON-schema convention from tamatebako/ruby (`versions.yml` / `schema/versions.schema.yml`).
- **Manifests:** `scripts/upload_release.rb` reads `contract.yml` (fail-closed if missing/malformed) and emits an additive `contract_version` key into **every** `manifest.json` package entry — all matrix rubies × platforms, since release assembly is per-package from the one value. Additive key, same compat rule as `image`: consumers ignoring it keep working.
- **Compiled into the runtime:** `#define TEBAKO_CONTRACT_VERSION 1` in `build/src/tebako-main.cpp` next to `TEBAKO_LAUNCHER_ABI_VERSION` (the repo's existing version-constant pattern). The driver exports it as the `TEBAKO_CONTRACT_VERSION` env var at the top of `tebako_main` (overwrite; miniruby pass-through untouched; `_putenv_s` on Windows).
- **CI agreement check:** `scripts/check_contract_version.rb` validates the YAML against the schema and diffs it against the compiled-in define; runs in the **prepare job** so a disagreement fails before the matrix builds anything. `spec/contract_spec.rb` covers agreement, schema violations, missing define, and drift with tmpdir fixtures.

## The next contract bump

Any change to env/argv/handoff semantics = **+1 in both representations, same commit** (`contract.yml` + the define in `tebako-main.cpp`). The agreement check fails the build otherwise; release manifests and the runtime env export then both carry the new value. Spec 06 (tebako-rs) gains the version→semantics row.

## Verification

- `bundle exec rspec`: 121 examples, 0 failures (13 pending are the `TEBAKO_RUNTIME_ROOT`-gated boot-smoke integration examples)
- `bundle exec rubocop`: no offenses on touched files
- `./scripts/check_contract_version.rb`: "contract version 1: contract.yml and the compiled-in TEBAKO_CONTRACT_VERSION agree"
- `clang++ -std=c++20 -fsyntax-only` on the modified driver TU: clean
- e2e: a locally built 3.3.7 runtime boots with the env export visible inside the packaged context (verified pre-merge; the PR matrix boot-smokes every leg)