### PR TITLE
factory: backport bundler's EROFS degradation for the 3.4 line (memfs process_lock)

### DIFF
--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -161,10 +161,13 @@ module BootSmokeProbe
 
   # Bundler's ProcessLock targets the bundle path -- Gem.dir, inside the
   # read-only memfs. Every supported bundler degrades to "no lock" there
-  # (2.5/2.6 rescue EROFS & co., 4.x wraps the failure as PermissionError);
-  # what must never escape is the drift-class errno (the unshimmed
-  # statx/fcopyfile EBADF the image-era boot gap died with -- it matched
-  # none of the rescues and aborted the boot).
+  # (<= 2.5 rescues EROFS & co. directly, 4.x wraps the failure as
+  # PermissionError; 2.6.0-2.6.5 lost the EROFS degradation upstream, so
+  # the factory backports it into 3.4-line images -- see
+  # ImageBuilder#backport_bundler_erofs_degradation); what must never
+  # escape is the drift-class errno (the unshimmed statx/fcopyfile EBADF
+  # the image-era boot gap died with -- it matched none of the rescues and
+  # aborted the boot).
   def self.process_lock_check
     require "bundler"
     unless defined?(Bundler::ProcessLock)

--- a/build/lib/tebako_runtime_builder/image_builder.rb
+++ b/build/lib/tebako_runtime_builder/image_builder.rb
@@ -46,7 +46,23 @@ module TebakoRuntimeBuilder
   # 30b) skip it: the executable carries zero-size incbin symbols and the
   # standalone <runtime>.tfs the ImagePackager writes from the same layout
   # tree is the runtime's only filesystem image.
+  #
+  # For the ruby 3.4 line the layout tree's bundled bundler is repaired on
+  # the way in: see backport_bundler_erofs_degradation.
   class ImageBuilder # rubocop:disable Metrics/ClassLength
+    # Anchor for the bundler EROFS backport below: the SystemCallError
+    # catch-all of SharedHelpers.filesystem_access, indented exactly as in
+    # the bundled file (unique there).
+    BUNDLER_RESCUE_ANCHOR = "    rescue SystemCallError => e\n"
+
+    # The backported branch. Upstream (bundler >= 2.6.6) raises
+    # ReadOnlyFileSystemError < PermissionError here; the backport raises
+    # the PermissionError the bundled bundler already defines -- the class
+    # ProcessLock rescues.
+    BUNDLER_EROFS_BRANCH =
+      "    rescue Errno::EROFS\n      " \
+      "raise PermissionError.new(path, action) # tebako backport (bundler < 2.6.6)\n"
+
     def initialize(platform, ruby_ver, stash_dir, data_src_dir, data_pre_dir, data_bin_file, deps_bin_dir, # rubocop:disable Metrics/ParameterLists,Metrics/MethodLength
                    embed: true)
       @platform = platform
@@ -65,6 +81,7 @@ module TebakoRuntimeBuilder
 
     def build(stub_dir)
       init
+      backport_bundler_erofs_degradation
       deploy(stub_dir)
       mkdwarfs if @embed
     end
@@ -78,6 +95,44 @@ module TebakoRuntimeBuilder
       puts "   ... creating packaging environment at #{@data_src_dir}"
       recreate([@data_src_dir, @data_pre_dir, File.dirname(@data_bin_file)])
       FileUtils.cp_r "#{@stash_dir}/.", @data_src_dir
+    end
+
+    # bundler 2.6.0-2.6.5 (the 2.6.2 ruby 3.4.0-3.4.2 bundles) moved
+    # ProcessLock under SharedHelpers.filesystem_access and narrowed its
+    # rescue to PermissionError, but that filesystem_access shape carries no
+    # Errno::EROFS branch: the read-only memfs answers the lockfile create
+    # with EROFS (the io.c tfs_open contract), which lands in the
+    # SystemCallError catch-all and escapes ProcessLock as
+    # GenericSystemCallError. bundler <= 2.5 rescued EROFS in ProcessLock
+    # itself; bundler >= 2.6.6 / 4.x maps it to ReadOnlyFileSystemError <
+    # PermissionError (the upstream fix this backports, reduced to the
+    # PermissionError the bundled bundler already carries). With the
+    # mapping, ProcessLock degrades to no-lock on the memfs like every
+    # supported line. Content-gated both ways: a layout tree whose bundler
+    # already tolerates EROFS (or predates the 2.6 shape and its anchor)
+    # passes through untouched, and the gate restricts the repair to the
+    # affected ruby line.
+    def backport_bundler_erofs_degradation
+      return unless @ruby_ver.ruby34only?
+
+      bundler_helpers_candidates.each do |helpers|
+        next unless File.file?(helpers)
+
+        content = File.read(helpers)
+        next if content.include?("rescue Errno::EROFS") || !content.include?(BUNDLER_RESCUE_ANCHOR)
+
+        puts "   ... backporting the EROFS process-lock degradation into #{helpers.sub("#{@data_src_dir}/", "")}"
+        File.write(helpers, content.sub(BUNDLER_RESCUE_ANCHOR, BUNDLER_EROFS_BRANCH + BUNDLER_RESCUE_ANCHOR))
+      end
+    end
+
+    # Candidate locations: the default-gem install lands bundler's lib files
+    # in the stdlib dir (lib/ruby/<api>/bundler/, the gems/ dir keeps only
+    # exe/); the gems/ glob covers layouts that hold the full gem there.
+    def bundler_helpers_candidates
+      candidates = [File.join(@data_src_dir, "lib", "ruby", @ruby_ver.api_version, "bundler", "shared_helpers.rb")]
+      candidates += Dir.glob(File.join(@tgd, "gems", "bundler-*/lib/bundler/shared_helpers.rb"))
+      candidates.uniq.sort
     end
 
     def deploy(stub_dir)

--- a/build/lib/tebako_runtime_builder/ruby_version.rb
+++ b/build/lib/tebako_runtime_builder/ruby_version.rb
@@ -71,6 +71,10 @@ module TebakoRuntimeBuilder
       @ruby33only ||= major_minor == [3, 3]
     end
 
+    def ruby34only?
+      @ruby34only ||= major_minor == [3, 4]
+    end
+
     def ruby3x7?
       @ruby3x7 ||= ruby34? ||
                    (ruby33only? && patch_version >= 7) ||

--- a/spec/image_builder_spec.rb
+++ b/spec/image_builder_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+
+# The image-content repair ImageBuilder applies for the ruby 3.4 line:
+# backport_bundler_erofs_degradation rewrites the layout tree's bundled
+# bundler so ProcessLock degrades to no-lock on the read-only memfs (the
+# bundler 2.6.0-2.6.5 gap fixed upstream in 2.6.6). Fixture indentation is
+# significant: the backport anchors on the bundled file's exact
+# SystemCallError catch-all line.
+
+# SharedHelpers.filesystem_access as bundled by ruby 3.4.0-3.4.2
+# (bundler 2.6.2): no Errno::EROFS branch.
+BUNDLER_262_SHAPE = <<~'RUBY'
+  module Bundler
+    module SharedHelpers
+      def filesystem_access(path, action = :write, &block)
+        yield(path.dup)
+      rescue Errno::EACCES => e
+        raise unless e.message.include?(path.to_s) || action == :create
+
+        raise PermissionError.new(path, action)
+      rescue Errno::EEXIST, Errno::ENOENT
+        raise
+      rescue SystemCallError => e
+        raise GenericSystemCallError.new(e, "There was an error accessing `#{path}`.")
+      end
+    end
+  end
+RUBY
+
+# The upstream-fixed shape (bundler >= 2.6.6 / 4.x): EROFS maps to
+# ReadOnlyFileSystemError < PermissionError already.
+BUNDLER_266_SHAPE = <<~'RUBY'
+  module Bundler
+    module SharedHelpers
+      def filesystem_access(path, action = :write, &block)
+        yield(path.dup)
+      rescue Errno::EACCES => e
+        raise unless e.message.include?(path.to_s) || action == :create
+
+        raise PermissionError.new(path, action)
+      rescue Errno::EROFS
+        raise ReadOnlyFileSystemError.new(path, action)
+      rescue Errno::EEXIST, Errno::ENOENT
+        raise
+      rescue SystemCallError => e
+        raise GenericSystemCallError.new(e, "There was an error accessing `#{path}`.")
+      end
+    end
+  end
+RUBY
+
+RSpec.describe TebakoRuntimeBuilder::ImageBuilder do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @dir = dir
+      example.run
+    end
+  end
+
+  def builder_for(ruby_version)
+    rv = TebakoRuntimeBuilder::RubyVersion.new(ruby_version)
+    platform = TebakoRuntimeBuilder::Platform.new("arm64-darwin23", "arm64")
+    described_class.new(platform, rv, File.join(@dir, "stash"), data_src_dir, File.join(@dir, "pre"),
+                        File.join(@dir, "out", "fs.bin"), File.join(@dir, "deps", "bin"), embed: false)
+  end
+
+  def data_src_dir
+    File.join(@dir, "s")
+  end
+
+  # The default-gem install lands bundler's lib files in the stdlib dir;
+  # the gems/ dir of a default gem keeps only exe/.
+  def write_bundler_helpers(content)
+    helpers = File.join(data_src_dir, "lib", "ruby", "3.4.0", "bundler", "shared_helpers.rb")
+    FileUtils.mkdir_p(File.dirname(helpers))
+    File.write(helpers, content)
+    helpers
+  end
+
+  def backport(ruby_version)
+    builder_for(ruby_version).send(:backport_bundler_erofs_degradation)
+  end
+
+  it "inserts the EROFS degradation ahead of the catch-all on the ruby 3.4 line" do
+    helpers = write_bundler_helpers(BUNDLER_262_SHAPE)
+
+    backport("3.4.2")
+
+    patched = File.read(helpers)
+    expect(patched).to include(described_class::BUNDLER_EROFS_BRANCH)
+    branch_at = patched.index(described_class::BUNDLER_EROFS_BRANCH)
+    anchor_at = patched.index(described_class::BUNDLER_RESCUE_ANCHOR)
+    expect(branch_at + described_class::BUNDLER_EROFS_BRANCH.length).to eq(anchor_at)
+  end
+
+  it "also reaches a bundler held fully under the gems dir" do
+    helpers = File.join(data_src_dir, "lib", "ruby", "gems", "3.4.0", "gems",
+                        "bundler-2.6.2", "lib", "bundler", "shared_helpers.rb")
+    FileUtils.mkdir_p(File.dirname(helpers))
+    File.write(helpers, BUNDLER_262_SHAPE)
+
+    backport("3.4.2")
+
+    expect(File.read(helpers)).to include(described_class::BUNDLER_EROFS_BRANCH)
+  end
+
+  it "keeps the patched file valid Ruby" do
+    helpers = write_bundler_helpers(BUNDLER_262_SHAPE)
+
+    backport("3.4.1")
+
+    expect { RubyVM::InstructionSequence.compile(File.read(helpers)) }.not_to raise_error
+  end
+
+  it "leaves an already EROFS-tolerant bundler untouched" do
+    helpers = write_bundler_helpers(BUNDLER_266_SHAPE)
+
+    backport("3.4.2")
+
+    expect(File.read(helpers)).to eq(BUNDLER_266_SHAPE)
+  end
+
+  it "leaves other ruby lines untouched even with the affected bundler shape" do
+    helpers = write_bundler_helpers(BUNDLER_262_SHAPE)
+
+    backport("3.3.7")
+    backport("4.0.6")
+
+    expect(File.read(helpers)).to eq(BUNDLER_262_SHAPE)
+  end
+
+  it "is a no-op when the layout tree carries no bundler" do
+    expect { backport("3.4.2") }.not_to raise_error
+  end
+end

--- a/spec/ruby_version_spec.rb
+++ b/spec/ruby_version_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe TebakoRuntimeBuilder::RubyVersion do
     expect(rv.ruby33only?).to be(true)
     expect(rv.ruby3x7?).to be(true)
     expect(rv.ruby34?).to be(false)
+    expect(rv.ruby34only?).to be(false)
+  end
+
+  it "treats 3.4.x as ruby34only" do
+    rv34 = described_class.new("3.4.2")
+    expect(rv34.ruby34?).to be(true)
+    expect(rv34.ruby34only?).to be(true)
+    expect(rv34.ruby33only?).to be(false)
   end
 
   it "treats 3.2.x as ruby32only" do
@@ -35,6 +43,7 @@ RSpec.describe TebakoRuntimeBuilder::RubyVersion do
   it "treats 4.x lines as ruby34 without string-indexing fallout" do
     rv40 = described_class.new("4.0.6")
     expect(rv40.ruby34?).to be(true)
+    expect(rv40.ruby34only?).to be(false)
     expect(rv40.ruby3x7?).to be(true)
     expect(rv40.ruby33only?).to be(false)
     expect(rv40.api_version).to eq("4.0.0")


### PR DESCRIPTION
## Root cause

Only rubies 3.4.1/3.4.2 failed the boot-smoke `process_lock` scenario — because they are the only matrix rubies bundling **bundler 2.6.2**, and bundler 2.6.0–2.6.5 has an upstream regression: `ProcessLock`'s rescue was narrowed to `PermissionError` and the `Errno::EROFS` branch was lost, so bundler's lockfile create against the read-only memfs escapes as `Bundler::GenericSystemCallError` instead of degrading to no-lock (upstream fixed in 2.6.6 — rubygems/rubygems#8519; rubies ≥ 3.4.3 and 4.0.x are clean, and ≤ 3.3 bundles bundler 2.5.x which rescues EROFS directly).

Confirmed twice before the fix: host repro on a read-only DMG (2.5.22 ok / 2.6.2 fail / 2.6.9 ok), and an in-runtime repro on a locally built no-fix 3.4.2 runtime.

The memfs layer is POSIX-correct and unchanged — EROFS on a write open inside the mount is exactly the signal upstream's own fix validates.

## Fix (factory-side, content-gated)

- `ImageBuilder#build` gains a `backport_bundler_erofs_degradation` step (after init, before deploy): on the ruby 3.4 line only, the layout tree's bundled bundler `shared_helpers.rb` gets the 2.6.6 fix reduced to the `PermissionError` 2.6.2 already defines (`rescue Errno::EROFS → raise PermissionError`), inserted ahead of the catch-all — so `ProcessLock` degrades to no-lock exactly like every supported line.
- **Content-gated both ways**: a bundler already carrying an EROFS branch (≥2.6.6 / 4.x) or lacking the 2.6 anchor shape passes through untouched; candidate paths cover default-gem stdlib and full-gem layouts.
- No driver/patch-layer changes, no new dependencies. Probe comment corrected (the "2.5/2.6 rescue EROFS" note was wrong about 2.6).

## Evidence

- Local macos-arm64 3.4.2 rebuilt with the fix: boot-smoke **19 examples, 0 failures**; probe reports `process_lock ok no-lock-on-memfs`.
- CI slice (workflow_dispatch linux-gnu/x86_64 + 3.4.2, run 30419953774): build job green, 19/19 — including "tolerates bundler's process lock on the read-only memfs".
- No regressions: 3.3.7 runtime against this spec 19/19; unit suite 109 examples green; rubocop clean.
- New specs: 6 image-builder examples (insertion position, gems-dir fallback, valid-Ruby result, fixed-shape untouched, non-3.4 untouched, no-bundler no-op) + the `ruby34only?` gate.

## Not in scope

Windows legs (the dir segfault — separate branch in flight) and musl (fixed in #23; 3.4.x musl legs now exercise this fix too).
