### PR TITLE
windows: the dir-layer trilogy — glob segfault, stat wire-layout, flock marker

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -489,7 +489,9 @@ message(STATUS "libyaml Ruby option='${LIBYAML_RUBY_OPTION}'")
 # The build-pass tooling (build/tools/build_pass.rb over build/lib) runs the
 # consumer-side steps the pre-patched source tree expects:
 #   prepare       -- substitute @TEBAKO_MLIBS@ in template/Makefile.in and
-#                    build the stub libtebako-fs.a for the toolchain link
+#                    build the stub libtebako-fs.a for the toolchain link;
+#                    on msys also guard the dir.c glob_opendir capacity hint
+#                    against the libtfs dir handles (hotfix_msys_glob_opendir!)
 #   postconfigure -- substitute S["MAINLIBS"] in the generated config.status
 #   toolchain     -- make + make install, stash the pristine environment
 #   overlay       -- (msys only) lay the pass-2 source tree onto the built

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -491,7 +491,8 @@ message(STATUS "libyaml Ruby option='${LIBYAML_RUBY_OPTION}'")
 #   prepare       -- substitute @TEBAKO_MLIBS@ in template/Makefile.in and
 #                    build the stub libtebako-fs.a for the toolchain link;
 #                    on msys also guard the dir.c glob_opendir capacity hint
-#                    against the libtfs dir handles (hotfix_msys_glob_opendir!)
+#                    against the libtfs dir handles and read libtfs' struct
+#                    stat fills through their wire layout (the hot-patches)
 #   postconfigure -- substitute S["MAINLIBS"] in the generated config.status
 #   toolchain     -- make + make install, stash the pristine environment
 #   overlay       -- (msys only) lay the pass-2 source tree onto the built

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -106,7 +106,9 @@ module BootSmokeProbe
 
   def self.stat_check
     stat = File.stat(STUB)
-    raise "#{STUB} is not a file" unless stat.file? && stat.size.positive?
+    unless stat.file? && stat.size.positive?
+      raise "#{STUB} is not a file (file?=#{stat.file?} size=#{stat.size} mode=#{stat.mode.to_s(8)})"
+    end
 
     "size=#{stat.size}"
   end
@@ -175,8 +177,8 @@ module BootSmokeProbe
   end
 
   # The memfs is read-only; the writable path is a host temporary file, so
-  # POSIX fcntl semantics pass through to the host fd. On msys the shimmed
-  # no-op lands with item 18 (the host spec pends until then).
+  # POSIX fcntl semantics pass through to the host fd (the memfs no-op shim
+  # of item 18 covers memfs fds, never this host one).
   def self.flock_check
     require "tmpdir"
     Dir.mktmpdir do |dir|

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -36,7 +36,8 @@ module TebakoRuntimeBuilder
   #
   #   prepare       -- substitute @TEBAKO_MLIBS@ in template/Makefile.in with
   #                    the platform static library list and build the stub
-  #                    libtebako-fs.a for the toolchain link
+  #                    libtebako-fs.a for the toolchain link; on msys also
+  #                    guard the dir.c glob_opendir capacity hint (below)
   #   postconfigure -- substitute S["MAINLIBS"] in the generated
   #                    config.status (the deferred patch of the canonical set)
   #   toolchain     -- make + make install, stash the pristine ruby
@@ -55,6 +56,30 @@ module TebakoRuntimeBuilder
     MSYS_MAINLIBS_LINE =
       "-lshell32 -lws2_32 -liphlpapi -limagehlp -lshlwapi -lbcrypt -lcrypt32 -ladvapi32 -luser32"
 
+    # msys dir.c hot-patch (glob_opendir capacity hint) ----------------------
+    #
+    # ruby's dir.c on _WIN32 reads the win32 DIR emulation's internals
+    # directly in glob_opendir():
+    #     if ((capacity = dirp->nfiles) > 0) {
+    # -- a pre-allocation hint for the sorted-glob entries array. The
+    # pre-patched msys dir.c routes opendir/readdir into the memfs via the
+    # libtfs c_api, whose tebako_fs_opendir() handle is a registry token
+    # (a small integer cast to void*), NOT a win32 DIR; the nfiles read
+    # dereferences it and segfaults the runtime at startup the first time
+    # rubygems glob-scans the memfs (Dir[] -> Primitive.dir_s_glob ->
+    # glob_opendir; every msys leg of the boot smoke). The guard skips the
+    # hint for memfs handles; the sorted path then grows the entries array
+    # by realloc, exactly like the POSIX build, which has no hint at all.
+    # tebako_fs_dir_is_embedded() is declared by the shim block the msys
+    # patch injects earlier into the same translation unit.
+    # Removal: once tamatebako/ruby's dir_c_memfs_msys.patch carries the
+    # guard in the released source tree the anchor below no longer matches
+    # and the substitution raises -- drop it together with the pin bump.
+    MSYS_GLOB_OPENDIR_ANCHOR = "if ((capacity = dirp->nfiles) > 0) {"
+    MSYS_GLOB_OPENDIR_GUARDED =
+      "if (!tebako_fs_dir_is_embedded((tebako_dir_t) dirp) /* tebako patch */ " \
+      "&& (capacity = dirp->nfiles) > 0) {"
+
     TOOLCHAIN_STUB_C = File.expand_path("../../resources/toolchain_stub.c", __dir__).freeze
 
     class << self # rubocop:disable Metrics/ClassLength
@@ -71,6 +96,9 @@ module TebakoRuntimeBuilder
           mlibs = TebakoRuntimeBuilder::Mlibs.new(platform, deps_lib_dir).compute(rv, with_compression: true)
           substitute_tebako_mlibs!(File.join(ruby_source_dir, "template", "Makefile.in"), mlibs)
         end
+        # msys only: guard the one direct win32-DIR access the io routing of
+        # the pre-patched dir.c does not cover (the constants above)
+        hotfix_msys_glob_opendir!(File.join(ruby_source_dir, "dir.c")) if platform.msys?
         build_toolchain_stub(platform, deps_lib_dir, mount_point, cc, rv)
       end
 
@@ -243,6 +271,34 @@ module TebakoRuntimeBuilder
 
         puts "   ... substituting #{TEBAKO_MLIBS_PLACEHOLDER} in #{makefile_in}"
         File.write(makefile_in, File.read(orig).gsub(TEBAKO_MLIBS_PLACEHOLDER, mlibs))
+      end
+
+      # Guard the dir.c glob_opendir() capacity hint against libtfs dir
+      # handles (MSYS_GLOB_OPENDIR_ANCHOR / MSYS_GLOB_OPENDIR_GUARDED above).
+      # Idempotent like substitute_tebako_mlibs!: the msys pass-2 overlay
+      # re-runs prepare over an already-guarded tree. Fails loudly when the
+      # tree matches neither the guard nor exactly one anchor -- that is the
+      # signal the released pre-patched source changed (the fix landed in
+      # tamatebako/ruby, or the upstream line moved) and this hot-patch must
+      # be revisited.
+      def hotfix_msys_glob_opendir!(dir_c) # rubocop:disable Metrics/MethodLength
+        unless File.exist?(dir_c)
+          raise TebakoRuntimeBuilder::Error.new("Could not patch #{dir_c} because it does not exist.", 107)
+        end
+
+        contents = File.read(dir_c)
+        return if contents.include?(MSYS_GLOB_OPENDIR_GUARDED)
+
+        anchor_count = contents.scan(MSYS_GLOB_OPENDIR_ANCHOR).length
+        unless anchor_count == 1
+          raise TebakoRuntimeBuilder::Error.new(
+            "#{dir_c}: expected exactly one glob_opendir capacity-hint anchor, found #{anchor_count} -- " \
+            "the pre-patched dir.c changed; revisit the msys glob_opendir hot-patch", 130
+          )
+        end
+
+        puts "   ... guarding dir.c glob_opendir capacity hint against libtfs dir handles (msys)"
+        File.write(dir_c, contents.sub(MSYS_GLOB_OPENDIR_ANCHOR, MSYS_GLOB_OPENDIR_GUARDED))
       end
 
       def substitute_config_status!(config_status, platform, mlibs) # rubocop:disable Metrics/MethodLength

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -37,7 +37,9 @@ module TebakoRuntimeBuilder
   #   prepare       -- substitute @TEBAKO_MLIBS@ in template/Makefile.in with
   #                    the platform static library list and build the stub
   #                    libtebako-fs.a for the toolchain link; on msys also
-  #                    guard the dir.c glob_opendir capacity hint (below)
+  #                    guard the dir.c glob_opendir capacity hint and read
+  #                    libtfs' struct stat fills through their wire layout
+  #                    (the hot-patches below)
   #   postconfigure -- substitute S["MAINLIBS"] in the generated
   #                    config.status (the deferred patch of the canonical set)
   #   toolchain     -- make + make install, stash the pristine ruby
@@ -46,7 +48,7 @@ module TebakoRuntimeBuilder
   #                    embedded shape, the fs.bin image incbin embeds)
   #   finalize      -- relink the ruby program against the real
   #                    libtebako-fs.a and strip it to the output package
-  module BuildPasses
+  module BuildPasses # rubocop:disable Metrics/ModuleLength
     TEBAKO_MLIBS_PLACEHOLDER = "@TEBAKO_MLIBS@"
 
     # config.status MAINLIBS defaults per platform (gem PatchBuildsystem);
@@ -80,10 +82,96 @@ module TebakoRuntimeBuilder
       "if (!tebako_fs_dir_is_embedded((tebako_dir_t) dirp) /* tebako patch */ " \
       "&& (capacity = dirp->nfiles) > 0) {"
 
+    # msys struct stat wire-layout hot-patch (libtfs c_api ABI) --------------
+    #
+    # ruby's configure runs AC_SYS_LARGEFILE: on mingw it defines
+    # _FILE_OFFSET_BITS=64, which widens this translation unit's struct stat
+    # st_size to 64 bits (and shifts every st_*time field behind it). The
+    # prebuilt libtfs is compiled WITHOUT the define and fills the DEFAULT
+    # ucrt layout (32-bit st_size -- and only st_mtime set, so st_atime is
+    # the memset zero the widened read of st_size lands on). The shim
+    # conversion the pre-patched source injects identically into dir.c,
+    # file.c and io.c (tfs_stat_to_stati128) therefore read a size of 0 for
+    # every memfs entry: File::Stat#size on a memfs path broke while
+    # file?/exist?/directory? kept working (st_mode sits before the
+    # divergence, and tebako_fs_stat itself succeeds). The replacement below
+    # reads the fill through the wire layout libtfs wrote.
+    # Removal: once tamatebako/ruby carries the wire-layout conversion in
+    # the released source, the anchor no longer matches and the substitution
+    # raises -- drop it together with the pin bump. The durable fix is an
+    # explicit, toolchain-flag-proof stat ABI in the libtfs c_api.
+    MSYS_STAT_CONVERSION_ANCHOR = <<~C.chomp
+      static void
+      tfs_stat_to_stati128(const struct stat *i, struct stati128 *o)
+      {
+          o->st_dev = i->st_dev;
+          o->st_ino = i->st_ino;
+          o->st_inohigh = 0;
+          o->st_mode = i->st_mode;
+          o->st_nlink = i->st_nlink;
+          o->st_uid = i->st_uid;
+          o->st_gid = i->st_gid;
+          o->st_rdev = i->st_rdev;
+          o->st_size = i->st_size;
+          o->st_atime = i->st_atime;
+          o->st_atimensec = 0;
+          o->st_mtime = i->st_mtime;
+          o->st_mtimensec = 0;
+          o->st_ctime = i->st_ctime;
+          o->st_ctimensec = 0;
+      }
+    C
+
+    MSYS_STAT_CONVERSION_REPLACEMENT = <<~C.chomp
+      /* The libtfs c_api fills the DEFAULT ucrt struct stat (32-bit st_size);
+         this translation unit has _FILE_OFFSET_BITS=64 from ruby's
+         AC_SYS_LARGEFILE, whose struct stat widens st_size to 64 bits and
+         shifts st_*time -- reading i->st_size picked up libtfs' never-filled
+         st_atime and File::Stat#size on a memfs path came back 0. Read the
+         fill through the wire layout libtfs wrote. */
+      struct tfs_wire_stat {
+          unsigned int st_dev;
+          unsigned short st_ino;
+          unsigned short st_mode;
+          short st_nlink;
+          short st_uid;
+          short st_gid;
+          unsigned int st_rdev;
+          long st_size;
+          long long st_atime;
+          long long st_mtime;
+          long long st_ctime;
+      };
+
+      static void
+      tfs_stat_to_stati128(const struct stat *i, struct stati128 *o)
+      {
+          const struct tfs_wire_stat *w = (const struct tfs_wire_stat *) i;
+          o->st_dev = w->st_dev;
+          o->st_ino = w->st_ino;
+          o->st_inohigh = 0;
+          o->st_mode = w->st_mode;
+          o->st_nlink = w->st_nlink;
+          o->st_uid = w->st_uid;
+          o->st_gid = w->st_gid;
+          o->st_rdev = w->st_rdev;
+          o->st_size = w->st_size;
+          o->st_atime = w->st_atime;
+          o->st_atimensec = 0;
+          o->st_mtime = w->st_mtime;
+          o->st_mtimensec = 0;
+          o->st_ctime = w->st_ctime;
+          o->st_ctimensec = 0;
+      }
+    C
+
+    MSYS_STAT_CONVERSION_MARKER = "struct tfs_wire_stat"
+    MSYS_STAT_CONVERSION_FILES = %w[dir.c file.c io.c].freeze
+
     TOOLCHAIN_STUB_C = File.expand_path("../../resources/toolchain_stub.c", __dir__).freeze
 
     class << self # rubocop:disable Metrics/ClassLength
-      def prepare(ostype, ruby_source_dir, deps_lib_dir, ruby_ver, mount_point, cc = "cc") # rubocop:disable Metrics/ParameterLists
+      def prepare(ostype, ruby_source_dir, deps_lib_dir, ruby_ver, mount_point, cc = "cc") # rubocop:disable Metrics/ParameterLists,Metrics/MethodLength
         puts "-- Running prepare script"
 
         platform = TebakoRuntimeBuilder::Platform.new(ostype)
@@ -97,8 +185,13 @@ module TebakoRuntimeBuilder
           substitute_tebako_mlibs!(File.join(ruby_source_dir, "template", "Makefile.in"), mlibs)
         end
         # msys only: guard the one direct win32-DIR access the io routing of
-        # the pre-patched dir.c does not cover (the constants above)
-        hotfix_msys_glob_opendir!(File.join(ruby_source_dir, "dir.c")) if platform.msys?
+        # the pre-patched dir.c does not cover, and read libtfs' struct stat
+        # fills through the wire layout they were written in (the constants
+        # above)
+        if platform.msys?
+          hotfix_msys_glob_opendir!(File.join(ruby_source_dir, "dir.c"))
+          hotfix_msys_stat_wire_layout!(ruby_source_dir)
+        end
         build_toolchain_stub(platform, deps_lib_dir, mount_point, cc, rv)
       end
 
@@ -299,6 +392,35 @@ module TebakoRuntimeBuilder
 
         puts "   ... guarding dir.c glob_opendir capacity hint against libtfs dir handles (msys)"
         File.write(dir_c, contents.sub(MSYS_GLOB_OPENDIR_ANCHOR, MSYS_GLOB_OPENDIR_GUARDED))
+      end
+
+      # Read libtfs' struct stat fills through the wire layout they were
+      # written in (MSYS_STAT_CONVERSION_* above). One anchored substitution
+      # per patched translation unit; idempotent like
+      # substitute_tebako_mlibs! (the msys pass-2 overlay re-runs prepare),
+      # loud when the anchor drifts (the pre-patched source changed -- the
+      # fix landed in tamatebako/ruby, or the conversion moved).
+      def hotfix_msys_stat_wire_layout!(ruby_source_dir) # rubocop:disable Metrics/MethodLength
+        MSYS_STAT_CONVERSION_FILES.each do |name|
+          path = File.join(ruby_source_dir, name)
+          unless File.exist?(path)
+            raise TebakoRuntimeBuilder::Error.new("Could not patch #{path} because it does not exist.", 107)
+          end
+
+          contents = File.read(path)
+          next if contents.include?(MSYS_STAT_CONVERSION_MARKER)
+
+          anchor_count = contents.scan(MSYS_STAT_CONVERSION_ANCHOR).length
+          unless anchor_count == 1
+            raise TebakoRuntimeBuilder::Error.new(
+              "#{path}: expected exactly one struct stat conversion anchor, found #{anchor_count} -- " \
+              "the pre-patched #{name} changed; revisit the msys stat wire-layout hot-patch", 130
+            )
+          end
+
+          puts "   ... reading libtfs struct stat fills through their wire layout in #{name} (msys)"
+          File.write(path, contents.sub(MSYS_STAT_CONVERSION_ANCHOR, MSYS_STAT_CONVERSION_REPLACEMENT))
+        end
       end
 
       def substitute_config_status!(config_status, platform, mlibs) # rubocop:disable Metrics/MethodLength

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -93,13 +93,14 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
 
       it "stats and lstats a memfs path" do
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("stat")).to eq("ok")
-        expect(run.state("lstat")).to eq("ok")
+        expect(run.state("stat")).to eq("ok"), "probe stat detail: #{run.detail("stat")}"
+        expect(run.state("lstat")).to eq("ok"), "probe lstat detail: #{run.detail("lstat")}"
       end
 
       it "fstats an open memfs file" do
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("fstat")).to eq("ok")
+        expect(run.state("fstat")).to eq("ok"), "probe fstat detail: #{run.detail("fstat")}"
+        expect(run.detail("fstat")).to match(/size=[1-9]\d*\z/)
       end
 
       it "exercises the birthtime/btime path" do
@@ -183,9 +184,11 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
       let(:run) { smoke.run("locks") }
 
       it "flocks a writable path (fcntl/POSIX semantics)" do
-        # On msys the flock shim lands as a no-op with item 18; pend until
-        # then (a pass here flips the pending and frees the marker).
-        pending "msys flock lands as a shim no-op with item 18" if smoke.platform.msys?
+        # The probe's writable path is a HOST temp file, so flock passes
+        # through to the host CRT flock unchanged on every platform -- the
+        # memfs no-op shim (item 18) covers memfs fds, which this check
+        # never touches. (Introduced pending on msys before any msys leg
+        # could boot; the first bootable msys runtime proved it stale.)
         expect(run).to be_booted, boot_failure(run)
         expect(run.state("flock_writable")).to eq("ok")
       end

--- a/spec/build_passes_spec.rb
+++ b/spec/build_passes_spec.rb
@@ -62,11 +62,50 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
 
     it "skips the template substitution on msys (MAINLIBS comes via config.status there)" do
       File.write(File.join(ruby_src, "template", "Makefile.in"), "MAINLIBS = @MAINLIBS@\n")
+      File.write(File.join(ruby_src, "dir.c"), "        if ((capacity = dirp->nfiles) > 0) {\n")
       expect do
         described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
       end.not_to raise_error
       expect(File.read(File.join(ruby_src, "template", "Makefile.in"))).to eq("MAINLIBS = @MAINLIBS@\n")
       expect(File.file?(File.join(deps_lib_dir, "libtebako-fs.a"))).to be(true)
+    end
+  end
+
+  describe ".prepare msys dir.c glob_opendir guard" do
+    let(:dir_c) { File.join(ruby_src, "dir.c") }
+    let(:anchor) { "        if ((capacity = dirp->nfiles) > 0) {" }
+
+    before do
+      File.write(dir_c, "#ifdef _WIN32\n#{anchor}\n#endif\n")
+    end
+
+    it "guards the nfiles capacity hint against libtfs dir handles" do
+      described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+
+      contents = File.read(dir_c)
+      expect(contents).to include("!tebako_fs_dir_is_embedded((tebako_dir_t) dirp) /* tebako patch */ && " \
+                                  "(capacity = dirp->nfiles) > 0")
+      expect(contents).not_to include("\n#{anchor}\n")
+    end
+
+    it "is idempotent across the msys pass-2 overlay prepare re-run" do
+      described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+      expect do
+        described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+      end.not_to raise_error
+      expect(File.read(dir_c).scan("dirp->nfiles").length).to eq(1)
+    end
+
+    it "fails loudly when the anchor is absent (the pre-patched tree changed)" do
+      File.write(dir_c, "#ifdef _WIN32\n        if ((capacity = 16) > 0) {\n#endif\n")
+      expect { described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc") }
+        .to raise_error(TebakoRuntimeBuilder::Error, /capacity-hint anchor/)
+    end
+
+    it "fails when dir.c does not exist" do
+      FileUtils.rm(dir_c)
+      expect { described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc") }
+        .to raise_error(TebakoRuntimeBuilder::Error, /does not exist/)
     end
   end
 

--- a/spec/build_passes_spec.rb
+++ b/spec/build_passes_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
     FileUtils.remove_entry(root)
   end
 
+  # An msys ruby source tree fixture carrying the anchors the prepare
+  # hot-patches act on (dir.c: the glob hint and the stat conversion;
+  # file.c/io.c: the stat conversion)
+  def write_msys_source_fixtures(dir)
+    conversion = TebakoRuntimeBuilder::BuildPasses::MSYS_STAT_CONVERSION_ANCHOR
+    glob = TebakoRuntimeBuilder::BuildPasses::MSYS_GLOB_OPENDIR_ANCHOR
+    File.write(File.join(dir, "dir.c"), "#{glob}\n#{conversion}\n")
+    File.write(File.join(dir, "file.c"), "#{conversion}\n")
+    File.write(File.join(dir, "io.c"), "#{conversion}\n")
+  end
+
   describe ".prepare" do
     before do
       File.write(File.join(ruby_src, "template", "Makefile.in"),
@@ -62,7 +73,7 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
 
     it "skips the template substitution on msys (MAINLIBS comes via config.status there)" do
       File.write(File.join(ruby_src, "template", "Makefile.in"), "MAINLIBS = @MAINLIBS@\n")
-      File.write(File.join(ruby_src, "dir.c"), "        if ((capacity = dirp->nfiles) > 0) {\n")
+      write_msys_source_fixtures(ruby_src)
       expect do
         described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
       end.not_to raise_error
@@ -76,7 +87,7 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
     let(:anchor) { "        if ((capacity = dirp->nfiles) > 0) {" }
 
     before do
-      File.write(dir_c, "#ifdef _WIN32\n#{anchor}\n#endif\n")
+      write_msys_source_fixtures(ruby_src)
     end
 
     it "guards the nfiles capacity hint against libtfs dir handles" do
@@ -85,7 +96,7 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
       contents = File.read(dir_c)
       expect(contents).to include("!tebako_fs_dir_is_embedded((tebako_dir_t) dirp) /* tebako patch */ && " \
                                   "(capacity = dirp->nfiles) > 0")
-      expect(contents).not_to include("\n#{anchor}\n")
+      expect(contents.scan("dirp->nfiles").length).to eq(1)
     end
 
     it "is idempotent across the msys pass-2 overlay prepare re-run" do
@@ -104,6 +115,43 @@ RSpec.describe TebakoRuntimeBuilder::BuildPasses do
 
     it "fails when dir.c does not exist" do
       FileUtils.rm(dir_c)
+      expect { described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc") }
+        .to raise_error(TebakoRuntimeBuilder::Error, /does not exist/)
+    end
+  end
+
+  describe ".prepare msys struct stat wire layout" do
+    before do
+      write_msys_source_fixtures(ruby_src)
+    end
+
+    it "reads libtfs struct stat fills through the wire layout in dir.c, file.c and io.c" do
+      described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+
+      %w[dir.c file.c io.c].each do |name|
+        contents = File.read(File.join(ruby_src, name))
+        expect(contents).to include("struct tfs_wire_stat")
+        expect(contents).to include("const struct tfs_wire_stat *w = (const struct tfs_wire_stat *) i;")
+        expect(contents).not_to include("o->st_size = i->st_size;")
+      end
+    end
+
+    it "is idempotent across the msys pass-2 overlay prepare re-run" do
+      described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+      expect do
+        described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc")
+      end.not_to raise_error
+      expect(File.read(File.join(ruby_src, "io.c")).scan("struct tfs_wire_stat {").length).to eq(1)
+    end
+
+    it "fails loudly when a conversion anchor is absent (the pre-patched tree changed)" do
+      File.write(File.join(ruby_src, "io.c"), "static void\nunrelated(void);\n")
+      expect { described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc") }
+        .to raise_error(TebakoRuntimeBuilder::Error, /struct stat conversion anchor/)
+    end
+
+    it "fails when a patched translation unit does not exist" do
+      FileUtils.rm(File.join(ruby_src, "file.c"))
       expect { described_class.prepare("x64-mingw-ucrt", ruby_src, deps_lib_dir, "3.3.7", "A:/__tebako_memfs__", "cc") }
         .to raise_error(TebakoRuntimeBuilder::Error, /does not exist/)
     end


### PR DESCRIPTION
## Summary

Windows legs were red across every ruby since the image-era boot-smoke began testing them — three independent bugs, all root-caused and fixed here. The slice run (windows/x86_64, ruby 3.3.7, run 30424374930) is **19/19 green**.

## 1. The segfault (13 failures): ruby's dir.c reads win32-DIR internals through a libtfs handle

`_WIN32` `glob_opendir()` pre-sizes its buffer from `dirp->nfiles` — a direct win32-`DIR` internals read. The tebako patch routes `opendir` into the memfs via libtfs, whose `tebako_fs_opendir()` returns a registry token (`(void*)1`), not a win32 `DIR` — so the `nfiles` read dereferences ~0x15 and segfaults at the first sorted glob over the memfs, which rubygems' spec scan performs at every interpreter startup. It's the only direct DIR-internals access on `_WIN32`; the anchor is byte-identical across ruby 3.1–4.0.

**Fix:** `BuildPasses.prepare` on msys guards the anchor with `!tebako_fs_dir_is_embedded((tebako_dir_t) dirp)` — memfs handles skip the hint and grow by realloc (the POSIX shape). Idempotent; fails loudly if the anchor disappears (forcing cleanup when tamatebako/ruby carries this upstream).

## 2. `File.stat`/`lstat` fail while `fstat` works: the stat wire-layout mismatch

libtfs fills the caller's stat buffer in ONE layout; the msys-patched ruby read it as another — every field came back wrong (`size=0`).

**Fix:** `tfs_stat_to_stati128` in dir.c/file.c/io.c now reads libtfs' fill through the default-ucrt wire layout (substitution ×3, idempotent, dry-run-verified against real pre-patched 3.3 trees; offset simulation reproduces `size=0 → size=225`; local rspec 129/0, rubocop clean). Includes probe/spec stat diagnostics so the next layout drift names its field values.

## 3. Housekeeping: the stale flock pending marker

msys `flock` passes on ucrt — the `pending 'msys flock lands as a shim no-op with item 18'` marker flipped the suite red precisely because the scenario now *works*. Removed; comment corrected.

## Validation

- Slice 30424374930 (windows/x86_64, 3.3.7): **19 examples, 0 failures**
- Slice 30419674072 (segfault fix alone): 13 → 2 failures
- Slice 30421981377 (pending-marker removal): flock passes
- Local: rspec 129/0, rubocop clean

## Out of scope

musl (fixed in #23) and the 3.4.x bundler EROFS backport (fixed in #24) — both already on main; this branch is rebased onto them. A tfs-ruby-side patch can eventually supersede the factory-side dir.c guard; the anchor-presence check forces that cleanup.
