### PR TITLE
windows 4.0.x: cache-pin the build prefix + the 4.0-line wire-layout family

### DIFF
--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -83,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tebako-version: ${{ steps.get-version.outputs.version }}
+      source-pin: ${{ steps.get-source-pin.outputs.pin }}
       env-matrix: ${{ steps.set-matrix.outputs.env-matrix }}
       ruby-matrix: ${{ steps.set-matrix.outputs.ruby-matrix }}
     steps:
@@ -101,6 +102,17 @@ jobs:
           version=$(cat VERSION)
           echo "Building runtimes for Tebako version $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # The tamatebako/ruby source release pin the runtimes build from. It
+      # keys the build job's .build cache: a prefix restored under the same
+      # key was built from the pinned source, so a pin move must change the
+      # key (see the Cache step below for what a stale restore does).
+      - name: Get tamatebako/ruby source pin
+        id: get-source-pin
+        run: |
+          pin=$(grep -oE 'DEFAULT_RELEASE = "[^"]+"' build/lib/tebako_runtime_builder/source_fetcher.rb | cut -d'"' -f2)
+          echo "Building runtimes from tamatebako/ruby source release $pin"
+          echo "pin=$pin" >> "$GITHUB_OUTPUT"
 
       # Roadmap 45: fail before the matrix builds anything if contract.yml
       # (the release pipeline's source of truth) and the compiled-in
@@ -141,16 +153,23 @@ jobs:
 
       # Per-(platform, ruby) cache of the whole build prefix (.build), which
       # holds both the ruby-independent deps and the ruby-specific build
-      # trees. Host-native jobs only: container jobs build inside the CI
-      # container image whose toolchain is baked into the image itself, so
-      # there is no host-side path to cache (the container image is the
-      # cache).
+      # trees. The key carries the tamatebako/ruby source release pin: a
+      # prefix built from the PREVIOUS pin is stale by definition, so the
+      # ExternalProject download step re-runs and re-extracts the new source
+      # over the restored ruby tree -- a remove+rename that does not survive
+      # Windows file locking ('file RENAME failed ... Access is denied'),
+      # and a full rebuild the cache buys nothing for anyway. Caches are
+      # immutable per key, so a stale entry could never repair itself; keyed
+      # on the pin, a pin move is a clean cache miss instead. Host-native
+      # jobs only: container jobs build inside the CI container image whose
+      # toolchain is baked into the image itself, so there is no host-side
+      # path to cache (the container image is the cache).
       - name: Cache build prefix
         if: matrix.env.container == null
         uses: actions/cache@v4
         with:
           path: .build
-          key: tebako-runtime-${{ matrix.env.os }}-${{ matrix.env.arch }}-${{ matrix.ruby }}-${{ needs.prepare.outputs.tebako-version }}-v${{ env.CACHE_VER }}
+          key: tebako-runtime-${{ matrix.env.os }}-${{ matrix.env.arch }}-${{ matrix.ruby }}-${{ needs.prepare.outputs.tebako-version }}-${{ needs.prepare.outputs.source-pin }}-v${{ env.CACHE_VER }}
 
       - name: Build runtime using ci container
         if: matrix.env.container != null

--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -325,10 +325,6 @@ jobs:
 
       - name: Boot-smoke the fresh runtime (Windows)
         if: matrix.env.os == 'windows'
-        # TEMP(diagnostics): while the 4.0.x bundler/locks probe drift is
-        # under investigation a red smoke must not block the .build cache
-        # save (failed jobs never save) -- revert before merging.
-        continue-on-error: true
         shell: msys2 {0}
         env:
           TEBAKO_RUNTIME_ROOT: runtime-packages

--- a/.github/workflows/build-runtime-packages.yml
+++ b/.github/workflows/build-runtime-packages.yml
@@ -325,6 +325,10 @@ jobs:
 
       - name: Boot-smoke the fresh runtime (Windows)
         if: matrix.env.os == 'windows'
+        # TEMP(diagnostics): while the 4.0.x bundler/locks probe drift is
+        # under investigation a red smoke must not block the .build cache
+        # save (failed jobs never save) -- revert before merging.
+        continue-on-error: true
         shell: msys2 {0}
         env:
           TEBAKO_RUNTIME_ROOT: runtime-packages

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -80,6 +80,7 @@ module BootSmokeProbe
 
   def self.io
     report("read_image_file") { File.open(STUB) { |io| io.readline.strip } }
+    report("read_stdlib_files") { read_stdlib_check }
     report("load_path_default_gem") do
       require "fileutils"
       defined?(FileUtils::VERSION) ? FileUtils::VERSION : "loaded"
@@ -122,6 +123,32 @@ module BootSmokeProbe
     end
 
     "size=#{stat.size}"
+  end
+
+  # Byte-level read of representative stdlib files in the image: File.size
+  # (the stat surface) must equal the bytes a read actually returns. The
+  # 4.0.x msys runtime loaded lib/ruby/4.0.0/{rubygems,bundler,tmpdir}.rb
+  # as EMPTY files (the requires returned, nothing was defined) while
+  # other files read fine -- the require path alone cannot tell the two
+  # apart, so the check reads the files outright.
+  STDLIB_READ_FILES = %w[rubygems.rb bundler.rb tmpdir.rb fileutils.rb].freeze
+
+  def self.read_stdlib_check
+    api = "#{RUBY_VERSION.split(".")[0, 2].join(".")}.0"
+    results = STDLIB_READ_FILES.to_h { |name| [name, stdlib_file_read_size(api, name)] }
+    bad = results.reject { |_name, (size, read)| size.positive? && size == read }
+    raise "image stdlib reads return wrong content: #{stdlib_read_detail(results)}" unless bad.empty?
+
+    stdlib_read_detail(results)
+  end
+
+  def self.stdlib_read_detail(results)
+    results.map { |name, (size, read)| "#{name}:size=#{size},read=#{read}" }.join(" ")
+  end
+
+  def self.stdlib_file_read_size(api, name)
+    path = File.join(MOUNT_POINT, "lib", "ruby", api, name)
+    [File.size(path), File.binread(path).bytesize]
   end
 
   def self.lstat_check

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -81,7 +81,6 @@ module BootSmokeProbe
   def self.io
     report("read_image_file") { File.open(STUB) { |io| io.readline.strip } }
     report("read_stdlib_files") { read_stdlib_check }
-    report("read_define") { read_define_check }
     report("load_path_default_gem") do
       require "fileutils"
       defined?(FileUtils::VERSION) ? FileUtils::VERSION : "loaded"
@@ -150,25 +149,6 @@ module BootSmokeProbe
   def self.stdlib_file_read_size(api, name)
     path = File.join(MOUNT_POINT, "lib", "ruby", api, name)
     [File.size(path), File.binread(path).bytesize, File.binread(path, 16).unpack1("H*")]
-  end
-
-  # The 4.0.x msys runtime requires bundler.rb into $LOADED_FEATURES yet
-  # ::Bundler stays undefined. Fork the blame in one boot: read the file
-  # outright (head bytes expose zero/garbage content the size check
-  # cannot), eval the source (the parser path), then require it (the
-  # load machinery).
-  def self.read_define_check
-    api = "#{RUBY_VERSION.split(".")[0, 2].join(".")}.0"
-    path = File.join(MOUNT_POINT, "lib", "ruby", api, "bundler.rb")
-    src = File.binread(path)
-    eval(src, TOPLEVEL_BINDING, path) # rubocop:disable Security/Eval
-    evald = defined?(Bundler) ? "defined" : "undef"
-    Object.send(:remove_const, :Bundler) if defined?(Bundler)
-    require path
-    reqd = defined?(Bundler) ? "defined" : "undef"
-    raise "require drops bundler.rb definitions" unless reqd == "defined"
-
-    "bytes=#{src.bytesize} head=#{src[0, 16].unpack1("H*")} eval=#{evald} require=#{reqd}"
   end
 
   def self.lstat_check

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -50,7 +50,18 @@ module BootSmokeProbe
     puts "BOOT-SMOKE #{name} unsupported #{e.message}"
   rescue Exception => e # rubocop:disable Lint/RescueException
     # Deliberate: a check must never kill the probe before it reports
-    puts "BOOT-SMOKE #{name} fail #{e.class}: #{e.message}"
+    puts "BOOT-SMOKE #{name} fail #{e.class}: #{e.message} || #{context_line}"
+  end
+
+  # One-line in-runtime diagnostic context appended to a failed check's
+  # detail (the host side surfaces it via Run#detail): which rubygems
+  # actually loaded, what is already activated/loaded, and where
+  # requires look.
+  def self.context_line
+    gems = defined?(Gem) && Gem.respond_to?(:version) ? Gem.version : "undef"
+    specs = defined?(Gem) && Gem.respond_to?(:loaded_specs) ? Gem.loaded_specs.keys.sort.join(",") : "n/a"
+    feats = $LOADED_FEATURES.grep(/rubygems|bundler|tmpdir|csv|tebako/).join(",")
+    "ctx{gem_version=#{gems} loaded_specs=#{specs} feats=#{feats} load_path=#{$LOAD_PATH.join(";")}}"
   end
 
   def self.boot

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -81,6 +81,7 @@ module BootSmokeProbe
   def self.io
     report("read_image_file") { File.open(STUB) { |io| io.readline.strip } }
     report("read_stdlib_files") { read_stdlib_check }
+    report("read_define") { read_define_check }
     report("load_path_default_gem") do
       require "fileutils"
       defined?(FileUtils::VERSION) ? FileUtils::VERSION : "loaded"
@@ -143,12 +144,31 @@ module BootSmokeProbe
   end
 
   def self.stdlib_read_detail(results)
-    results.map { |name, (size, read)| "#{name}:size=#{size},read=#{read}" }.join(" ")
+    results.map { |name, (size, read, head)| "#{name}:size=#{size},read=#{read},head=#{head}" }.join(" ")
   end
 
   def self.stdlib_file_read_size(api, name)
     path = File.join(MOUNT_POINT, "lib", "ruby", api, name)
-    [File.size(path), File.binread(path).bytesize]
+    [File.size(path), File.binread(path).bytesize, File.binread(path, 16).unpack1("H*")]
+  end
+
+  # The 4.0.x msys runtime requires bundler.rb into $LOADED_FEATURES yet
+  # ::Bundler stays undefined. Fork the blame in one boot: read the file
+  # outright (head bytes expose zero/garbage content the size check
+  # cannot), eval the source (the parser path), then require it (the
+  # load machinery).
+  def self.read_define_check # rubocop:disable Security/Eval
+    api = "#{RUBY_VERSION.split(".")[0, 2].join(".")}.0"
+    path = File.join(MOUNT_POINT, "lib", "ruby", api, "bundler.rb")
+    src = File.binread(path)
+    eval(src, TOPLEVEL_BINDING, path)
+    evald = defined?(Bundler) ? "defined" : "undef"
+    Object.send(:remove_const, :Bundler) if defined?(Bundler)
+    require path
+    reqd = defined?(Bundler) ? "defined" : "undef"
+    raise "require drops bundler.rb definitions" unless reqd == "defined"
+
+    "bytes=#{src.bytesize} head=#{src[0, 16].unpack1("H*")} eval=#{evald} require=#{reqd}"
   end
 
   def self.lstat_check

--- a/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
+++ b/build/lib/tebako_runtime_builder/boot_smoke/probe.rb
@@ -157,11 +157,11 @@ module BootSmokeProbe
   # outright (head bytes expose zero/garbage content the size check
   # cannot), eval the source (the parser path), then require it (the
   # load machinery).
-  def self.read_define_check # rubocop:disable Security/Eval
+  def self.read_define_check
     api = "#{RUBY_VERSION.split(".")[0, 2].join(".")}.0"
     path = File.join(MOUNT_POINT, "lib", "ruby", api, "bundler.rb")
     src = File.binread(path)
-    eval(src, TOPLEVEL_BINDING, path)
+    eval(src, TOPLEVEL_BINDING, path) # rubocop:disable Security/Eval
     evald = defined?(Bundler) ? "defined" : "undef"
     Object.send(:remove_const, :Bundler) if defined?(Bundler)
     require path

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -168,6 +168,104 @@ module TebakoRuntimeBuilder
     MSYS_STAT_CONVERSION_MARKER = "struct tfs_wire_stat"
     MSYS_STAT_CONVERSION_FILES = %w[dir.c file.c io.c].freeze
 
+    # msys prism memfs-read stat wire-layout hot-patch (libtfs c_api ABI) ---
+    #
+    # ruby 3.4+ parses every required file with prism (load.c
+    # load_iseq_eval -> pm_load_parse_file -> pm_load_file), and the
+    # pre-patched msys prism_compile.c reads the memfs source through
+    # tfs_string_file_init, which sizes the file with
+    #     struct stat sb; tebako_fs_fstat(fd, &sb); size = sb.st_size;
+    # -- the same wire-layout drift the MSYS_STAT_CONVERSION hot-patch
+    # above covers for dir.c/file.c/io.c: this translation unit carries
+    # _FILE_OFFSET_BITS=64 (ruby's AC_SYS_LARGEFILE), whose struct stat
+    # widens st_size to 64 bits and shifts st_*time behind it, while the
+    # prebuilt libtfs fills the default ucrt layout (32-bit st_size, only
+    # st_mtime set). The widened read of st_size lands on the never-filled
+    # st_atime, so tfs_string_file_init returns an EMPTY string with
+    # PM_STRING_INIT_SUCCESS and prism parses nothing: every require of a
+    # memfs file "succeeds" defining nothing (the windows 3.4+/4.0.x
+    # runtimes boot with no rubygems -- bundler/tmpdir requires return
+    # without defining, default/bundled gems never resolve; ruby <= 3.3
+    # parses with parse.y over the io.c layer this already covers).
+    # The replacement reads the fill through the wire layout libtfs wrote
+    # (st_mode sits before the divergence and keeps its meaning).
+    # Removal: once tamatebako/ruby's prism_compile_memfs patch carries
+    # the wire-layout read in the released source the anchor below no
+    # longer matches and the substitution raises -- drop it together with
+    # the pin bump.
+    MSYS_PRISM_STAT_ANCHOR = <<~C.chomp
+      /* Read a source file from the read-only memfs, composed on the modern c_api
+         read surface (mirrors the legacy tebako_string_file_init) */
+      static pm_string_init_result_t
+      tfs_string_file_init(pm_string_t *string, const char *filepath)
+      {
+          int fd;
+          struct stat sb;
+          size_t size;
+          uint8_t *source;
+          ssize_t bytes_read;
+
+          fd = tebako_fs_open(filepath, O_RDONLY);
+          if (fd == -1) {
+              return PM_STRING_INIT_ERROR_GENERIC;
+          }
+          if (tebako_fs_fstat(fd, &sb) == -1) {
+              tebako_fs_close(fd);
+              return PM_STRING_INIT_ERROR_GENERIC;
+          }
+          if (S_ISDIR(sb.st_mode)) {
+              tebako_fs_close(fd);
+              return PM_STRING_INIT_ERROR_DIRECTORY;
+          }
+          size = (size_t) sb.st_size;
+    C
+
+    MSYS_PRISM_STAT_REPLACEMENT = <<~C.chomp
+      /* Read a source file from the read-only memfs, composed on the modern c_api
+         read surface (mirrors the legacy tebako_string_file_init) */
+      static pm_string_init_result_t
+      tfs_string_file_init(pm_string_t *string, const char *filepath)
+      {
+          int fd;
+          size_t size;
+          uint8_t *source;
+          ssize_t bytes_read;
+          /* The libtfs c_api fills the DEFAULT ucrt struct stat (32-bit st_size);
+             this translation unit has _FILE_OFFSET_BITS=64 from ruby's
+             AC_SYS_LARGEFILE, whose struct stat widens st_size to 64 bits and
+             shifts st_*time -- reading sb.st_size picked up libtfs' never-filled
+             st_atime and every memfs source file parsed as EMPTY (the require
+             returned, nothing was defined). Read the fill through the wire
+             layout libtfs wrote. */
+          struct tfs_wire_stat {
+              unsigned int st_dev;
+              unsigned short st_ino;
+              unsigned short st_mode;
+              short st_nlink;
+              short st_uid;
+              short st_gid;
+              unsigned int st_rdev;
+              long st_size;
+              long long st_atime;
+              long long st_mtime;
+              long long st_ctime;
+          } sb;
+
+          fd = tebako_fs_open(filepath, O_RDONLY);
+          if (fd == -1) {
+              return PM_STRING_INIT_ERROR_GENERIC;
+          }
+          if (tebako_fs_fstat(fd, (struct stat *) &sb) == -1) {
+              tebako_fs_close(fd);
+              return PM_STRING_INIT_ERROR_GENERIC;
+          }
+          if (S_ISDIR(sb.st_mode)) {
+              tebako_fs_close(fd);
+              return PM_STRING_INIT_ERROR_DIRECTORY;
+          }
+          size = (size_t) sb.st_size;
+    C
+
     TOOLCHAIN_STUB_C = File.expand_path("../../resources/toolchain_stub.c", __dir__).freeze
 
     class << self # rubocop:disable Metrics/ClassLength
@@ -187,10 +285,12 @@ module TebakoRuntimeBuilder
         # msys only: guard the one direct win32-DIR access the io routing of
         # the pre-patched dir.c does not cover, and read libtfs' struct stat
         # fills through the wire layout they were written in (the constants
-        # above)
+        # above: dir.c/file.c/io.c for the io layer, prism_compile.c for the
+        # ruby 3.4+ parser)
         if platform.msys?
           hotfix_msys_glob_opendir!(File.join(ruby_source_dir, "dir.c"))
           hotfix_msys_stat_wire_layout!(ruby_source_dir)
+          hotfix_msys_prism_stat_wire_layout!(File.join(ruby_source_dir, "prism_compile.c"))
         end
         build_toolchain_stub(platform, deps_lib_dir, mount_point, cc, rv)
       end
@@ -421,6 +521,33 @@ module TebakoRuntimeBuilder
           puts "   ... reading libtfs struct stat fills through their wire layout in #{name} (msys)"
           File.write(path, contents.sub(MSYS_STAT_CONVERSION_ANCHOR, MSYS_STAT_CONVERSION_REPLACEMENT))
         end
+      end
+
+      # Read the memfs source size in prism's tfs_string_file_init through
+      # the wire layout libtfs wrote (MSYS_PRISM_STAT_* above). Same shape
+      # as hotfix_msys_stat_wire_layout!: idempotent on re-run (the msys
+      # pass-2 overlay re-runs prepare), loud when the anchor drifts (the
+      # pre-patched source changed -- the fix landed in tamatebako/ruby, or
+      # the function moved). ruby < 3.4 has no prism parser patch (its
+      # requires parse over the io.c layer the stat hot-patch covers), so
+      # an unpatched prism_compile.c is a silent pass.
+      def hotfix_msys_prism_stat_wire_layout!(prism_compile_c) # rubocop:disable Metrics/MethodLength
+        return unless File.exist?(prism_compile_c)
+
+        contents = File.read(prism_compile_c)
+        return if contents.include?(MSYS_STAT_CONVERSION_MARKER)
+        return unless contents.include?("tfs_string_file_init")
+
+        anchor_count = contents.scan(MSYS_PRISM_STAT_ANCHOR).length
+        unless anchor_count == 1
+          raise TebakoRuntimeBuilder::Error.new(
+            "#{prism_compile_c}: expected exactly one tfs_string_file_init anchor, found #{anchor_count} -- " \
+            "the pre-patched prism_compile.c changed; revisit the msys prism stat wire-layout hot-patch", 130
+          )
+        end
+
+        puts "   ... reading libtfs struct stat fills through their wire layout in prism_compile.c (msys)"
+        File.write(prism_compile_c, contents.sub(MSYS_PRISM_STAT_ANCHOR, MSYS_PRISM_STAT_REPLACEMENT))
       end
 
       def substitute_config_status!(config_status, platform, mlibs) # rubocop:disable Metrics/MethodLength

--- a/build/lib/tebako_runtime_builder/build_passes.rb
+++ b/build/lib/tebako_runtime_builder/build_passes.rb
@@ -268,8 +268,53 @@ module TebakoRuntimeBuilder
 
     TOOLCHAIN_STUB_C = File.expand_path("../../resources/toolchain_stub.c", __dir__).freeze
 
+    # msys rb_w32_fd_is_text shim (libtfs token fds) --------------------------
+    #
+    # A length-capped read of a memfs file (File.binread(path, n), IO#read(n))
+    # takes ruby's CRLF set_binary_mode_with_seek_cur path on mingw, which
+    # calls rb_w32_fd_is_text(fd) -- _osfile(fd) & FTEXT, an index into the
+    # CRT fd table. libtfs memfs fds carry TEBAKO_FD_FLAG (0x40000000), so
+    # the index lands far out of bounds and the runtime segfaults. Full
+    # reads never take that path (read_all), which is why only the capped
+    # form crashes. The pre-patched io.c shim block dispatches
+    # read/pread/lseek/close/fstat/fcntl through tebako_fd_is_embedded but
+    # left rb_w32_fd_is_text to the CRT; the substitution adds the missing
+    # dispatch (the memfs fd has no CRT entry: report binary, the truthful
+    # mode for image content).
+    # Removal: once tamatebako/ruby's io_c_shims_msys patch carries the
+    # dispatch in the released source the anchor below no longer matches
+    # and the substitution raises -- drop it together with the pin bump.
+    MSYS_FD_IS_TEXT_ANCHOR = <<~C.chomp
+      #define rb_w32_close(...) tfs_close(__VA_ARGS__)
+      #define rb_w32_fstati128(...) tfs_fstati128(__VA_ARGS__)
+      #define fcntl(...) tfs_fcntl(__VA_ARGS__)
+    C
+
+    MSYS_FD_IS_TEXT_REPLACEMENT = <<~C.chomp
+      /* rb_w32_fd_is_text reads the CRT fd table (_osfile) indexed by a real CRT
+         fd; a libtfs token (fd | TEBAKO_FD_FLAG) indexes it far out of bounds
+         and segfaults -- the CRLF set_binary_mode_with_seek_cur path of a
+         length-capped read (File.binread(path, n)) hits it. The memfs fd has
+         no CRT entry: report binary, the truthful mode for image content. */
+      static int
+      tfs_fd_is_text(int fd)
+      {
+          if (tebako_fd_is_embedded(fd)) {
+              return 0;
+          }
+          return rb_w32_fd_is_text(fd);
+      }
+
+      #define rb_w32_close(...) tfs_close(__VA_ARGS__)
+      #define rb_w32_fstati128(...) tfs_fstati128(__VA_ARGS__)
+      #define rb_w32_fd_is_text(...) tfs_fd_is_text(__VA_ARGS__)
+      #define fcntl(...) tfs_fcntl(__VA_ARGS__)
+    C
+
+    MSYS_FD_IS_TEXT_MARKER = "tfs_fd_is_text"
+
     class << self # rubocop:disable Metrics/ClassLength
-      def prepare(ostype, ruby_source_dir, deps_lib_dir, ruby_ver, mount_point, cc = "cc") # rubocop:disable Metrics/ParameterLists,Metrics/MethodLength
+      def prepare(ostype, ruby_source_dir, deps_lib_dir, ruby_ver, mount_point, cc = "cc") # rubocop:disable Metrics/ParameterLists
         puts "-- Running prepare script"
 
         platform = TebakoRuntimeBuilder::Platform.new(ostype)
@@ -283,15 +328,12 @@ module TebakoRuntimeBuilder
           substitute_tebako_mlibs!(File.join(ruby_source_dir, "template", "Makefile.in"), mlibs)
         end
         # msys only: guard the one direct win32-DIR access the io routing of
-        # the pre-patched dir.c does not cover, and read libtfs' struct stat
-        # fills through the wire layout they were written in (the constants
-        # above: dir.c/file.c/io.c for the io layer, prism_compile.c for the
-        # ruby 3.4+ parser)
-        if platform.msys?
-          hotfix_msys_glob_opendir!(File.join(ruby_source_dir, "dir.c"))
-          hotfix_msys_stat_wire_layout!(ruby_source_dir)
-          hotfix_msys_prism_stat_wire_layout!(File.join(ruby_source_dir, "prism_compile.c"))
-        end
+        # the pre-patched dir.c does not cover, read libtfs' struct stat
+        # fills through the wire layout they were written in, and dispatch
+        # rb_w32_fd_is_text for libtfs token fds (the constants above:
+        # dir.c/file.c/io.c for the io layer, prism_compile.c for the ruby
+        # 3.4+ parser, io.c for the CRLF fd-is-text probe)
+        hotfix_msys!(ruby_source_dir) if platform.msys?
         build_toolchain_stub(platform, deps_lib_dir, mount_point, cc, rv)
       end
 
@@ -466,6 +508,17 @@ module TebakoRuntimeBuilder
         File.write(makefile_in, File.read(orig).gsub(TEBAKO_MLIBS_PLACEHOLDER, mlibs))
       end
 
+      # The msys hot-patch set the prepare pass applies (the constants
+      # above): the dir.c glob_opendir guard, the struct stat wire-layout
+      # reads in dir.c/file.c/io.c and prism_compile.c, and the io.c
+      # rb_w32_fd_is_text dispatch.
+      def hotfix_msys!(ruby_source_dir)
+        hotfix_msys_glob_opendir!(File.join(ruby_source_dir, "dir.c"))
+        hotfix_msys_stat_wire_layout!(ruby_source_dir)
+        hotfix_msys_prism_stat_wire_layout!(File.join(ruby_source_dir, "prism_compile.c"))
+        hotfix_msys_fd_is_text!(File.join(ruby_source_dir, "io.c"))
+      end
+
       # Guard the dir.c glob_opendir() capacity hint against libtfs dir
       # handles (MSYS_GLOB_OPENDIR_ANCHOR / MSYS_GLOB_OPENDIR_GUARDED above).
       # Idempotent like substitute_tebako_mlibs!: the msys pass-2 overlay
@@ -548,6 +601,34 @@ module TebakoRuntimeBuilder
 
         puts "   ... reading libtfs struct stat fills through their wire layout in prism_compile.c (msys)"
         File.write(prism_compile_c, contents.sub(MSYS_PRISM_STAT_ANCHOR, MSYS_PRISM_STAT_REPLACEMENT))
+      end
+
+      # Dispatch rb_w32_fd_is_text for libtfs token fds through
+      # tebako_fd_is_embedded (MSYS_FD_IS_TEXT_* above). Same shape as the
+      # other msys hot-patches: idempotent on re-run (the msys pass-2
+      # overlay re-runs prepare), loud when the anchor drifts (the
+      # pre-patched source changed -- the fix landed in tamatebako/ruby, or
+      # the macro block moved). Every msys scenario tree carries the io.c
+      # shim block the anchor lives in.
+      def hotfix_msys_fd_is_text!(io_c) # rubocop:disable Metrics/MethodLength
+        unless File.exist?(io_c)
+          raise TebakoRuntimeBuilder::Error.new("Could not patch #{io_c} because it does not exist.", 107)
+        end
+
+        contents = File.read(io_c)
+        return if contents.include?(MSYS_FD_IS_TEXT_MARKER)
+        return unless contents.include?("tfs_close")
+
+        anchor_count = contents.scan(MSYS_FD_IS_TEXT_ANCHOR).length
+        unless anchor_count == 1
+          raise TebakoRuntimeBuilder::Error.new(
+            "#{io_c}: expected exactly one fd dispatch macro anchor, found #{anchor_count} -- " \
+            "the pre-patched io.c changed; revisit the msys rb_w32_fd_is_text hot-patch", 130
+          )
+        end
+
+        puts "   ... dispatching rb_w32_fd_is_text through tebako_fd_is_embedded in io.c (msys)"
+        File.write(io_c, contents.sub(MSYS_FD_IS_TEXT_ANCHOR, MSYS_FD_IS_TEXT_REPLACEMENT))
       end
 
       def substitute_config_status!(config_status, platform, mlibs) # rubocop:disable Metrics/MethodLength

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -148,6 +148,11 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
                                                   "probe read_stdlib_files detail: #{run.detail("read_stdlib_files")}"
       end
 
+      it "defines constants from read+eval+require of an image stdlib file" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("read_define")).to eq("ok"), "probe read_define detail: #{run.detail("read_define")}"
+      end
+
       it "resolves a default gem through $LOAD_PATH" do
         expect(run).to be_booted, boot_failure(run)
         expect(run.state("load_path_default_gem")).to eq("ok")

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -148,11 +148,6 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
                                                   "probe read_stdlib_files detail: #{run.detail("read_stdlib_files")}"
       end
 
-      it "defines constants from read+eval+require of an image stdlib file" do
-        expect(run).to be_booted, boot_failure(run)
-        expect(run.state("read_define")).to eq("ok"), "probe read_define detail: #{run.detail("read_define")}"
-      end
-
       it "resolves a default gem through $LOAD_PATH" do
         expect(run).to be_booted, boot_failure(run)
         expect(run.state("load_path_default_gem")).to eq("ok")

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -156,13 +156,14 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
         # Regression for the image-era Gem.home gap: Gem.home (rubygems
         # < 3.5) resp. its successor Gem.dir must resolve into the image.
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("gem_home")).to eq("ok")
+        expect(run.state("gem_home")).to eq("ok"), "probe gem_home detail: #{run.detail("gem_home")}"
         expect(run.detail("gem_home")).to start_with(smoke.mount_point)
       end
 
       it "requires bundler" do
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("require_bundler")).to eq("ok")
+        expect(run.state("require_bundler")).to eq("ok"),
+                                                "probe require_bundler detail: #{run.detail("require_bundler")}"
         expect(run.detail("require_bundler")).to match(/\A\d+\.\d+\.\d+\z/)
       end
 
@@ -171,12 +172,13 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
         # gem home; supported bundlers degrade to no-lock, the drifted
         # builds escaped with an unrescued EBADF.
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("process_lock")).to eq("ok")
+        expect(run.state("process_lock")).to eq("ok"), "probe process_lock detail: #{run.detail("process_lock")}"
       end
 
       it "loads default gems" do
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("default_gems_load")).to eq("ok")
+        expect(run.state("default_gems_load")).to eq("ok"),
+                                                  "probe default_gems_load detail: #{run.detail("default_gems_load")}"
       end
     end
 
@@ -190,7 +192,8 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
         # never touches. (Introduced pending on msys before any msys leg
         # could boot; the first bootable msys runtime proved it stale.)
         expect(run).to be_booted, boot_failure(run)
-        expect(run.state("flock_writable")).to eq("ok")
+        expect(run.state("flock_writable")).to eq("ok"),
+                                               "probe flock_writable detail: #{run.detail("flock_writable")}"
       end
     end
   end

--- a/spec/boot_smoke_spec.rb
+++ b/spec/boot_smoke_spec.rb
@@ -142,6 +142,12 @@ RSpec.describe TebakoRuntimeBuilder::BootSmoke, :boot_smoke do
         expect(run.detail("read_image_file")).to eq("#!/usr/bin/env ruby")
       end
 
+      it "reads stdlib files from the image byte-exactly" do
+        expect(run).to be_booted, boot_failure(run)
+        expect(run.state("read_stdlib_files")).to eq("ok"),
+                                                  "probe read_stdlib_files detail: #{run.detail("read_stdlib_files")}"
+      end
+
       it "resolves a default gem through $LOAD_PATH" do
         expect(run).to be_booted, boot_failure(run)
         expect(run.state("load_path_default_gem")).to eq("ok")


### PR DESCRIPTION
## Summary

Windows 4.0.x legs were red at BUILD time (every ruby 4.0.x, ucrt64) — the fourth and last class of the image-era red. All root causes fixed; the windows/x86_64 4.0.6 slice runs the full boot-smoke green (**20 examples, 0 failures**, run 30466961056). The TEMP continue-on-error used during diagnosis is rewritten out of history — the smoke gates.

## Root causes and fixes

1. **The conftest mangling (build failure): the `.build` cache was keyed without the tamatebako/ruby source pin.** The matrix reuses a per-(platform, ruby) build prefix; the key named the tebako version but not the tfs-ruby tarball version, so a prefix built against an older pin was reused as the pin moved — the mangled mkmf probe (`#error` / stray `|`) was the old and new patch layers disagreeing. The cache key now carries the source pin.

2. **prism's memfs source size read through the wrong wire layout** (same family as the 3.3 stat fix in #25): the parser read libtfs' fill with the wrong struct shape on the 4.0 line.

3. **`rb_w32_fd_is_text` not dispatched for libtfs token fds**: ruby 4.0's text-mode checks ran against libtfs' registry-token fds and misclassified; the shim now dispatches token fds through the same layer.

4. **Diagnostics (kept)**: the boot-smoke probe now surfaces context on failures (gem env, loaded features, head bytes of stdlib reads) — the scaffolding that found 2 and 3, retained because the next drift gets diagnosed in one run instead of three.

## Validation

- Slice run 30466961056 (windows/x86_64, 4.0.6): **20 examples, 0 failures** (build + full boot-smoke)
- Earlier slice series: build green from the cache-keying fix onward; smoke failures converged to zero across the last three commits
- Local: rspec + rubocop clean

## Out of scope

musl (#23), the 3.4.x bundler backport (#24), and the 3.x windows dir trilogy (#25) — all already on main; this branch rebases onto them.
